### PR TITLE
시즌 에피소드 UI 및 기능 추가

### DIFF
--- a/public/json/season.json
+++ b/public/json/season.json
@@ -1546,7 +1546,7 @@
       ]
     },
     {
-      "air_date": "2021-09-17",
+      "air_date": "2026-09-17",
       "episode_number": 9,
       "episode_type": "finale",
       "id": 3222798,

--- a/src/components/DetailModal/Model/Episodes.ts
+++ b/src/components/DetailModal/Model/Episodes.ts
@@ -1,4 +1,4 @@
-export interface Season {
+export interface Episodes {
 	id: string;
 	name: string;
 	airDate: string;
@@ -20,7 +20,7 @@ export interface Episode {
 
 // air_date가 현재보다 이전이면 active, 이후라면 inactive?
 
-export const mapSeason = (json: any): Season => ({
+export const mapEpisodes = (json: any): Episodes => ({
 	id: json.id,
 	name: json.name,
 	airDate: json.air_date,

--- a/src/components/DetailModal/Model/Season.ts
+++ b/src/components/DetailModal/Model/Season.ts
@@ -1,0 +1,38 @@
+export interface Season {
+	id: string;
+	name: string;
+	airDate: string;
+	overview: string;
+	posterPath: string;
+	episodes: Episode[];
+}
+
+export interface Episode {
+	airDate: string; // 볼 수 있는 날짜
+	episodeNumber: number; // 회차
+	id: number;
+	name: string;
+	overview: string;
+	runtime: number;
+	// showID: number;
+	stillPath: string; // 볼수있는 날짜가 현재보다 작으면 표시
+}
+
+// air_date가 현재보다 이전이면 active, 이후라면 inactive?
+
+export const mapSeason = (json: any): Season => ({
+	id: json.id,
+	name: json.name,
+	airDate: json.air_date,
+	overview: json.overview,
+	posterPath: json.poster_path,
+	episodes: json.episodes.map((episode: any) => ({
+		airDate: episode.air_date,
+		episodeNumber: episode.episode_number,
+		id: episode.id,
+		name: episode.name,
+		overview: episode.overview,
+		runtime: episode.runtime,
+		stillPath: episode.still_path,
+	})),
+});

--- a/src/components/DetailModal/components/ModalDropdown.tsx
+++ b/src/components/DetailModal/components/ModalDropdown.tsx
@@ -1,0 +1,74 @@
+import React, { FC, useRef, useState } from "react";
+import { Season } from "../Model/VideoDetail";
+import useOnClickOutside from "../../../hooks/useOnclickOutside";
+
+interface ModalDropdownProps {
+	seasons: Season[];
+	onSelect: (season: Season) => void;
+	selectedSeason: Season;
+}
+
+const ModalDropdown: FC<ModalDropdownProps> = ({
+	seasons,
+	onSelect,
+	selectedSeason,
+}) => {
+	const ref = useRef<HTMLDivElement>(null);
+	const [isOpen, setIsOpen] = useState(false);
+
+	useOnClickOutside({ ref: ref, handler: () => setIsOpen(false) });
+
+	const handleClick = () => {
+		setIsOpen(!isOpen);
+	};
+
+	const handleSelect = (season: Season) => {
+		onSelect(season);
+		setIsOpen(false);
+	};
+
+	return (
+		<div className="relative justify-self-end" ref={ref}>
+			<button
+				className="px-4 py-2 bg-neutral-800 text-white rounded-md flex justify-between items-center border-neutral-700 border-2 font-bold gap-5"
+				onClick={() => handleClick()}
+			>
+				{selectedSeason.name}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					className={`h-4 w-4 transition-transform ${
+						isOpen ? "rotate-180" : ""
+					}`}
+					fill="currentColor"
+					viewBox="0 0 24 24"
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						strokeWidth="2"
+						d="M19 9l-7 7-7-7"
+					/>
+				</svg>
+			</button>
+			{isOpen && (
+				<div className="absolute whitespace-nowrap z-10 right-0 mt-2 bg-neutral-800 text-white border-neutral-700 border-2 py-2">
+					{seasons.map((season, index) => (
+						<div key={index}>
+							<button
+								onClick={() => {
+									handleSelect(season);
+								}}
+								className="flex min-w-32 px-4 py-2 text-white hover:bg-neutral-500 items-center"
+							>
+								<p className="font-bold">{season.name}</p>
+								<p className="text-xs">{`(${season.episodeCount}개 에피소드)`}</p>
+							</button>
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default ModalDropdown;

--- a/src/components/DetailModal/components/ModalEpisode.tsx
+++ b/src/components/DetailModal/components/ModalEpisode.tsx
@@ -2,12 +2,16 @@ import React, { FC } from "react";
 import { Episode } from "../Model/Episodes";
 
 interface ModalEpisodeProps {
-  backdropPath: string;
+	backdropPath: string;
 	episode: Episode;
 	isFocus: boolean;
 }
 
-const ModalEpisode: FC<ModalEpisodeProps> = ({ backdropPath, episode, isFocus }) => {
+const ModalEpisode: FC<ModalEpisodeProps> = ({
+	backdropPath,
+	episode,
+	isFocus,
+}) => {
 	const convertMinutesToHoursAndMinutes = (totalMinutes: number): string => {
 		const hours = Math.floor(totalMinutes / 60); // 시간을 계산
 		const minutes = totalMinutes % 60; // 남은 분 계산
@@ -22,10 +26,10 @@ const ModalEpisode: FC<ModalEpisodeProps> = ({ backdropPath, episode, isFocus })
 		return inputDate < today;
 	};
 
-  const formatDate = (dateString: string): string => {
-    const [year, month, day] = dateString.split("-").map(Number); // 문자열 분리 및 숫자로 변환
-    return `${month}월 ${day}일`; // 원하는 형식으로 반환
-  };
+	const formatDate = (dateString: string): string => {
+		const [year, month, day] = dateString.split("-").map(Number); // 문자열 분리 및 숫자로 변환
+		return `${month}월 ${day}일`; // 원하는 형식으로 반환
+	};
 
 	return isPastDate(episode.airDate) ? (
 		<div
@@ -49,9 +53,7 @@ const ModalEpisode: FC<ModalEpisodeProps> = ({ backdropPath, episode, isFocus })
 			<div className="absolute bottom-0 left-0 w-full h-px bg-neutral-800"></div>
 		</div>
 	) : (
-		<div
-			className="relative flex items-center p-4 min-h-32 rounded-md bg-black"
-		>
+		<div className="relative flex items-center p-4 min-h-32 rounded-md bg-black">
 			<p className="text-xl px-4">{episode.episodeNumber}</p>
 			<img
 				className="flex w-10 sm:w-14 md:w-24 lg:w-40 h-auto aspect-video rounded-md"
@@ -62,7 +64,9 @@ const ModalEpisode: FC<ModalEpisodeProps> = ({ backdropPath, episode, isFocus })
 				<div className="flex justify-between pt-4 px-4 pb-2">
 					<p className="font-semibold">{episode.name}</p>
 				</div>
-				<p className="text-neutral-400 text-sm px-4 pb-4">{`${formatDate(episode.airDate)} 공개`}</p>
+				<p className="text-neutral-400 text-sm px-4 pb-4">{`${formatDate(
+					episode.airDate
+				)} 공개`}</p>
 			</div>
 			<div className="absolute bottom-0 left-0 w-full h-px bg-neutral-800"></div>
 		</div>

--- a/src/components/DetailModal/components/ModalEpisode.tsx
+++ b/src/components/DetailModal/components/ModalEpisode.tsx
@@ -53,7 +53,7 @@ const ModalEpisode: FC<ModalEpisodeProps> = ({
 			<div className="absolute bottom-0 left-0 w-full h-px bg-neutral-800"></div>
 		</div>
 	) : (
-		<div className="relative flex items-center p-4 min-h-32 rounded-md bg-black">
+		<div className="relative flex items-center p-4 min-h-3 bg-black">
 			<p className="text-xl px-4">{episode.episodeNumber}</p>
 			<img
 				className="flex w-10 sm:w-14 md:w-24 lg:w-40 h-auto aspect-video rounded-md"

--- a/src/components/DetailModal/components/ModalEpisode.tsx
+++ b/src/components/DetailModal/components/ModalEpisode.tsx
@@ -3,7 +3,7 @@ import { Episode } from "../Model/Episodes";
 
 interface ModalEpisodeProps {
 	episode: Episode;
-  isFocus: boolean;
+	isFocus: boolean;
 }
 
 const ModalEpisode: FC<ModalEpisodeProps> = ({ episode, isFocus }) => {
@@ -14,7 +14,11 @@ const ModalEpisode: FC<ModalEpisodeProps> = ({ episode, isFocus }) => {
 	};
 
 	return (
-		<div className={`relative flex items-center p-4 min-h-32 rounded-md ${isFocus ? 'bg-neutral-800' : 'bg-transparent'}`}>
+		<div
+			className={`relative flex items-center p-4 min-h-32 rounded-md ${
+				isFocus ? "bg-neutral-800" : "bg-transparent"
+			}`}
+		>
 			<p className="text-xl px-4">{episode.episodeNumber}</p>
 			<img
 				className="flex w-10 sm:w-14 md:w-24 lg:w-40 h-auto aspect-video rounded-md"
@@ -28,7 +32,7 @@ const ModalEpisode: FC<ModalEpisodeProps> = ({ episode, isFocus }) => {
 				</div>
 				<p className="text-neutral-400 text-sm px-4 pb-4">{episode.overview}</p>
 			</div>
-      <div className="absolute bottom-0 left-0 w-full h-px bg-neutral-800"></div>
+			<div className="absolute bottom-0 left-0 w-full h-px bg-neutral-800"></div>
 		</div>
 	);
 };

--- a/src/components/DetailModal/components/ModalEpisode.tsx
+++ b/src/components/DetailModal/components/ModalEpisode.tsx
@@ -11,7 +11,7 @@ const ModalEpisode: FC<ModalEpisodeProps> = ({ backdropPath, episode, isFocus })
 	const convertMinutesToHoursAndMinutes = (totalMinutes: number): string => {
 		const hours = Math.floor(totalMinutes / 60); // 시간을 계산
 		const minutes = totalMinutes % 60; // 남은 분 계산
-		return `${hours}시간 ${minutes}분`;
+		return hours > 0 ? `${hours}시간 ${minutes}분` : `${minutes}분`;
 	};
 
 	const isPastDate = (dateString: string): boolean => {

--- a/src/components/DetailModal/components/ModalEpisode.tsx
+++ b/src/components/DetailModal/components/ModalEpisode.tsx
@@ -2,18 +2,32 @@ import React, { FC } from "react";
 import { Episode } from "../Model/Episodes";
 
 interface ModalEpisodeProps {
+  backdropPath: string;
 	episode: Episode;
 	isFocus: boolean;
 }
 
-const ModalEpisode: FC<ModalEpisodeProps> = ({ episode, isFocus }) => {
+const ModalEpisode: FC<ModalEpisodeProps> = ({ backdropPath, episode, isFocus }) => {
 	const convertMinutesToHoursAndMinutes = (totalMinutes: number): string => {
 		const hours = Math.floor(totalMinutes / 60); // 시간을 계산
 		const minutes = totalMinutes % 60; // 남은 분 계산
 		return `${hours}시간 ${minutes}분`;
 	};
 
-	return (
+	const isPastDate = (dateString: string): boolean => {
+		const inputDate = new Date(dateString);
+		const today = new Date();
+
+		today.setHours(0, 0, 0, 0); // 현재 날짜를 yyyy-MM-dd 기준으로 초기화
+		return inputDate < today;
+	};
+
+  const formatDate = (dateString: string): string => {
+    const [year, month, day] = dateString.split("-").map(Number); // 문자열 분리 및 숫자로 변환
+    return `${month}월 ${day}일`; // 원하는 형식으로 반환
+  };
+
+	return isPastDate(episode.airDate) ? (
 		<div
 			className={`relative flex items-center p-4 min-h-32 rounded-md ${
 				isFocus ? "bg-neutral-800" : "bg-transparent"
@@ -31,6 +45,24 @@ const ModalEpisode: FC<ModalEpisodeProps> = ({ episode, isFocus }) => {
 					<p>{convertMinutesToHoursAndMinutes(episode.runtime)}</p>
 				</div>
 				<p className="text-neutral-400 text-sm px-4 pb-4">{episode.overview}</p>
+			</div>
+			<div className="absolute bottom-0 left-0 w-full h-px bg-neutral-800"></div>
+		</div>
+	) : (
+		<div
+			className="relative flex items-center p-4 min-h-32 rounded-md bg-black"
+		>
+			<p className="text-xl px-4">{episode.episodeNumber}</p>
+			<img
+				className="flex w-10 sm:w-14 md:w-24 lg:w-40 h-auto aspect-video rounded-md"
+				src={`https://image.tmdb.org/t/p/original/${backdropPath}`}
+				alt="episode-poster-img"
+			/>
+			<div className="flex-[0_0_70%]">
+				<div className="flex justify-between pt-4 px-4 pb-2">
+					<p className="font-semibold">{episode.name}</p>
+				</div>
+				<p className="text-neutral-400 text-sm px-4 pb-4">{`${formatDate(episode.airDate)} 공개`}</p>
 			</div>
 			<div className="absolute bottom-0 left-0 w-full h-px bg-neutral-800"></div>
 		</div>

--- a/src/components/DetailModal/components/ModalEpisode.tsx
+++ b/src/components/DetailModal/components/ModalEpisode.tsx
@@ -1,0 +1,36 @@
+import React, { FC } from "react";
+import { Episode } from "../Model/Episodes";
+
+interface ModalEpisodeProps {
+	episode: Episode;
+  isFocus: boolean;
+}
+
+const ModalEpisode: FC<ModalEpisodeProps> = ({ episode, isFocus }) => {
+	const convertMinutesToHoursAndMinutes = (totalMinutes: number): string => {
+		const hours = Math.floor(totalMinutes / 60); // 시간을 계산
+		const minutes = totalMinutes % 60; // 남은 분 계산
+		return `${hours}시간 ${minutes}분`;
+	};
+
+	return (
+		<div className={`relative flex items-center p-4 min-h-32 rounded-md ${isFocus ? 'bg-neutral-800' : 'bg-transparent'}`}>
+			<p className="text-xl px-4">{episode.episodeNumber}</p>
+			<img
+				className="flex w-10 sm:w-14 md:w-24 lg:w-40 h-auto aspect-video rounded-md"
+				src={`https://image.tmdb.org/t/p/original/${episode.stillPath}`}
+				alt="episode-poster-img"
+			/>
+			<div className="flex-[0_0_70%]">
+				<div className="flex justify-between pt-4 px-4 pb-2">
+					<p className="font-semibold">{episode.name}</p>
+					<p>{convertMinutesToHoursAndMinutes(episode.runtime)}</p>
+				</div>
+				<p className="text-neutral-400 text-sm px-4 pb-4">{episode.overview}</p>
+			</div>
+      <div className="absolute bottom-0 left-0 w-full h-px bg-neutral-800"></div>
+		</div>
+	);
+};
+
+export default ModalEpisode;

--- a/src/components/DetailModal/components/ModalEpisodes.tsx
+++ b/src/components/DetailModal/components/ModalEpisodes.tsx
@@ -1,29 +1,41 @@
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import { Season } from "../Model/VideoDetail";
 import { Episodes } from "../Model/Episodes";
 import ModalEpisode from "./ModalEpisode";
+import ModalDropdown from "./ModalDropdown";
 
 interface ModalEpisodesProps {
 	backdropPath: string;
 	seasons: Season[];
 	episodes: Episodes;
+	selectedSeason: (season: Season) => void;
 }
 
 const ModalEpisodes: FC<ModalEpisodesProps> = ({
 	backdropPath,
 	seasons,
 	episodes,
+	selectedSeason,
 }) => {
+	const [season, setSeason] = useState(seasons[seasons.length - 1]);
+
+	const handleSeasonSelect = (season: Season) => {
+		setSeason(season);
+		selectedSeason(season);
+	};
+
 	return (
 		<div className="px-12 py-8">
 			<div className="grid gap-8 grid-cols-[2fr_1fr]">
 				<p className="text-xl">회차</p>
-				<p>시즌</p>
+				<ModalDropdown
+					seasons={seasons}
+					onSelect={handleSeasonSelect}
+					selectedSeason={season}
+				/>
 			</div>
 			{seasons.length > 1 && (
-				<p className="text-sm pt-4">{`시즌 ${
-					seasons.at(-1)?.seasonNumber
-				}:`}</p>
+				<p className="text-sm pt-4">{`${season.name}:`}</p>
 			)}
 			<div className="flex flex-col justify-start flex-wrap pt-3">
 				{episodes.episodes.map((episode, index) => (

--- a/src/components/DetailModal/components/ModalEpisodes.tsx
+++ b/src/components/DetailModal/components/ModalEpisodes.tsx
@@ -4,11 +4,12 @@ import { Episodes } from "../Model/Episodes";
 import ModalEpisode from "./ModalEpisode";
 
 interface ModalEpisodesProps {
+	backdropPath: string;
 	seasons: Season[];
 	episodes: Episodes;
 }
 
-const ModalEpisodes: FC<ModalEpisodesProps> = ({ seasons, episodes }) => {
+const ModalEpisodes: FC<ModalEpisodesProps> = ({ backdropPath, seasons, episodes }) => {
 	return (
 		<div className="px-12 py-8">
 			<div className="grid gap-8 grid-cols-[2fr_1fr]">
@@ -22,7 +23,7 @@ const ModalEpisodes: FC<ModalEpisodesProps> = ({ seasons, episodes }) => {
 			)}
 			<div className="flex flex-col justify-start flex-wrap pt-3">
 				{episodes.episodes.map((episode, index) => (
-					<ModalEpisode episode={episode} isFocus={index === 0} />
+					<ModalEpisode backdropPath={backdropPath} episode={episode} isFocus={index === 0} />
 				))}
 			</div>
 		</div>

--- a/src/components/DetailModal/components/ModalEpisodes.tsx
+++ b/src/components/DetailModal/components/ModalEpisodes.tsx
@@ -1,0 +1,29 @@
+import React, { FC } from "react";
+import { Season } from "../Model/VideoDetail";
+import { Episodes } from "../Model/Episodes";
+
+interface ModalEpisodesProps {
+	seasons: Season[];
+	episodes: Episodes;
+}
+
+const ModalEpisodes: FC<ModalEpisodesProps> = ({ seasons, episodes }) => {
+	return (
+		<div className="px-12 py-8">
+			<div className="grid gap-8 grid-cols-[2fr_1fr]">
+				<p className="text-xl">회차</p>
+				<p>시즌</p>
+			</div>
+			{seasons.length > 1 && (
+				<p className="text-sm">{`시즌 ${seasons.at(-1)?.seasonNumber}:`}</p>
+			)}
+			<div className="">
+				{episodes.episodes.map((episode) => (
+					<p>{episode.name}</p>
+				))}
+			</div>
+		</div>
+	);
+};
+
+export default ModalEpisodes;

--- a/src/components/DetailModal/components/ModalEpisodes.tsx
+++ b/src/components/DetailModal/components/ModalEpisodes.tsx
@@ -18,10 +18,20 @@ const ModalEpisodes: FC<ModalEpisodesProps> = ({
 	selectedSeason,
 }) => {
 	const [season, setSeason] = useState(seasons[seasons.length - 1]);
+	const [showEpNumber, setShowEpNumber] = useState(5); // TODO: 10으로 늘려야함
 
 	const handleSeasonSelect = (season: Season) => {
 		setSeason(season);
 		selectedSeason(season);
+	};
+
+	const handleExpanded = () => {
+		if (showEpNumber < episodes.episodes.length) {
+			// 전체 에피소드보다 적은 경우 더 보기 동작
+			setShowEpNumber((prev) => Math.min(prev + 5, episodes.episodes.length));
+		} else {
+			setShowEpNumber((prev) => Math.max(prev - 5, 5));
+		}
 	};
 
 	return (
@@ -38,13 +48,37 @@ const ModalEpisodes: FC<ModalEpisodesProps> = ({
 				<p className="text-sm pt-4">{`${season.name}:`}</p>
 			)}
 			<div className="flex flex-col justify-start flex-wrap pt-3">
-				{episodes.episodes.map((episode, index) => (
+				{episodes.episodes.slice(0, showEpNumber).map((episode, index) => (
 					<ModalEpisode
 						backdropPath={backdropPath}
 						episode={episode}
 						isFocus={index === 0}
 					/>
 				))}
+			</div>
+			<div className="flex bottom-0 left-0 w-full h-1 bg-neutral-700 justify-center items-center ">
+				<button
+					className="w-8 h-8 flex items-center justify-center bg-neutral-800 border border-white rounded-full z-10"
+					onClick={() => {
+						handleExpanded();
+					}}
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						className={`h-4 w-4 transition-transform ${
+							showEpNumber >= episodes.episodes.length ? "rotate-180" : ""
+						}`}
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
+						<path
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							strokeWidth="2"
+							d="M19 9l-7 7-7-7"
+						/>
+					</svg>
+				</button>
 			</div>
 		</div>
 	);

--- a/src/components/DetailModal/components/ModalEpisodes.tsx
+++ b/src/components/DetailModal/components/ModalEpisodes.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from "react";
 import { Season } from "../Model/VideoDetail";
 import { Episodes } from "../Model/Episodes";
+import ModalEpisode from "./ModalEpisode";
 
 interface ModalEpisodesProps {
 	seasons: Season[];
@@ -15,11 +16,13 @@ const ModalEpisodes: FC<ModalEpisodesProps> = ({ seasons, episodes }) => {
 				<p>시즌</p>
 			</div>
 			{seasons.length > 1 && (
-				<p className="text-sm">{`시즌 ${seasons.at(-1)?.seasonNumber}:`}</p>
+				<p className="text-sm pt-4">{`시즌 ${
+					seasons.at(-1)?.seasonNumber
+				}:`}</p>
 			)}
-			<div className="">
-				{episodes.episodes.map((episode) => (
-					<p>{episode.name}</p>
+			<div className="flex flex-col justify-start flex-wrap pt-3">
+				{episodes.episodes.map((episode, index) => (
+					<ModalEpisode episode={episode} isFocus={index === 0} />
 				))}
 			</div>
 		</div>

--- a/src/components/DetailModal/components/ModalEpisodes.tsx
+++ b/src/components/DetailModal/components/ModalEpisodes.tsx
@@ -9,7 +9,11 @@ interface ModalEpisodesProps {
 	episodes: Episodes;
 }
 
-const ModalEpisodes: FC<ModalEpisodesProps> = ({ backdropPath, seasons, episodes }) => {
+const ModalEpisodes: FC<ModalEpisodesProps> = ({
+	backdropPath,
+	seasons,
+	episodes,
+}) => {
 	return (
 		<div className="px-12 py-8">
 			<div className="grid gap-8 grid-cols-[2fr_1fr]">
@@ -23,7 +27,11 @@ const ModalEpisodes: FC<ModalEpisodesProps> = ({ backdropPath, seasons, episodes
 			)}
 			<div className="flex flex-col justify-start flex-wrap pt-3">
 				{episodes.episodes.map((episode, index) => (
-					<ModalEpisode backdropPath={backdropPath} episode={episode} isFocus={index === 0} />
+					<ModalEpisode
+						backdropPath={backdropPath}
+						episode={episode}
+						isFocus={index === 0}
+					/>
 				))}
 			</div>
 		</div>

--- a/src/components/DetailModal/components/ModalInfoSummary.tsx
+++ b/src/components/DetailModal/components/ModalInfoSummary.tsx
@@ -18,7 +18,7 @@ const ModalInfoSummary: FC<ModalInfoSummaryProps> = ({
 	const convertMinutesToHoursAndMinutes = (totalMinutes: number): string => {
 		const hours = Math.floor(totalMinutes / 60); // 시간을 계산
 		const minutes = totalMinutes % 60; // 남은 분 계산
-		return `${hours}시간 ${minutes}분`;
+		return hours > 0 ? `${hours}시간 ${minutes}분` : `${minutes}분`;
 	};
 
 	const convertReleaseDate = (releaseDate: string): string => {

--- a/src/components/DetailModal/page.tsx
+++ b/src/components/DetailModal/page.tsx
@@ -11,7 +11,7 @@ import ModalHeader from "./components/ModalHeader";
 import ModalPoster from "./components/ModalPoster";
 import ModalPosterButtons from "./components/ModalPosterButtons";
 import ModalInfoSummary from "./components/ModalInfoSummary";
-import { mapMovie, mapTV, MediaType, Movie, Series } from "./Model/VideoDetail";
+import { mapMovie, mapTV, MediaType, Movie, Season, Series } from "./Model/VideoDetail";
 import ModalInfoDetail from "./components/ModalInfoDetail";
 import { Credit, mapCredit } from "./Model/Credit";
 import { Keywords, mapKeywords } from "./Model/Keyword";
@@ -100,6 +100,11 @@ const DetailModal: FC<DetailModalProps> = ({ mediaType, setIsModalOpen }) => {
 		}
 	};
 
+	const handleSeasonSelect = (season: Season) => {
+		// API 연결 시 시즌 업데이트
+		console.log(season);
+	};
+
 	return (
 		<div className="presenter z-10 absolute min-h-screen">
 			{video && credit && keyword && episodes ? (
@@ -121,6 +126,7 @@ const DetailModal: FC<DetailModalProps> = ({ mediaType, setIsModalOpen }) => {
 							backdropPath={video.backdropPath}
 							seasons={(video as Series).seasons}
 							episodes={episodes}
+							selectedSeason={handleSeasonSelect}
 						/>
 						<ModalInfoDetail
 							video={video}

--- a/src/components/DetailModal/page.tsx
+++ b/src/components/DetailModal/page.tsx
@@ -11,7 +11,14 @@ import ModalHeader from "./components/ModalHeader";
 import ModalPoster from "./components/ModalPoster";
 import ModalPosterButtons from "./components/ModalPosterButtons";
 import ModalInfoSummary from "./components/ModalInfoSummary";
-import { mapMovie, mapTV, MediaType, Movie, Season, Series } from "./Model/VideoDetail";
+import {
+	mapMovie,
+	mapTV,
+	MediaType,
+	Movie,
+	Season,
+	Series,
+} from "./Model/VideoDetail";
 import ModalInfoDetail from "./components/ModalInfoDetail";
 import { Credit, mapCredit } from "./Model/Credit";
 import { Keywords, mapKeywords } from "./Model/Keyword";
@@ -107,7 +114,7 @@ const DetailModal: FC<DetailModalProps> = ({ mediaType, setIsModalOpen }) => {
 
 	return (
 		<div className="presenter z-10 absolute min-h-screen">
-			{video && credit && keyword && episodes ? (
+			{video && credit && keyword ? (
 				<div className="wrapper-model fixed inset-0 bg-black bg-opacity-70 flex items-start justify-center overflow-auto">
 					<div
 						className="modal relative bg-neutral-900 w-full max-w-6xl mt-8 mx-2 rounded-lg overflow-auto"
@@ -122,12 +129,14 @@ const DetailModal: FC<DetailModalProps> = ({ mediaType, setIsModalOpen }) => {
 							casts={credit.cast}
 							keywords={keyword.keywords}
 						/>
-						<ModalEpisodes
-							backdropPath={video.backdropPath}
-							seasons={(video as Series).seasons}
-							episodes={episodes}
-							selectedSeason={handleSeasonSelect}
-						/>
+						{episodes && (
+							<ModalEpisodes
+								backdropPath={video.backdropPath}
+								seasons={(video as Series).seasons}
+								episodes={episodes}
+								selectedSeason={handleSeasonSelect}
+							/>
+						)}
 						<ModalInfoDetail
 							video={video}
 							credit={credit}

--- a/src/components/DetailModal/page.tsx
+++ b/src/components/DetailModal/page.tsx
@@ -15,6 +15,8 @@ import { mapMovie, mapTV, MediaType, Movie, Series } from "./Model/VideoDetail";
 import ModalInfoDetail from "./components/ModalInfoDetail";
 import { Credit, mapCredit } from "./Model/Credit";
 import { Keywords, mapKeywords } from "./Model/Keyword";
+import ModalEpisodes from "./components/ModalEpisodes";
+import { Episodes, mapEpisodes } from "./Model/Episodes";
 
 interface DetailModalProps {
 	// id: int,
@@ -25,6 +27,7 @@ interface DetailModalProps {
 const DetailModal: FC<DetailModalProps> = ({ mediaType, setIsModalOpen }) => {
 	const ref = useRef<HTMLDivElement | null>(null);
 	const [video, setVideo] = useState<Movie | Series | null>(null);
+	const [episodes, setEpisodes] = useState<Episodes | null>(null);
 	const [credit, setCredit] = useState<Credit | null>(null);
 	const [keyword, setKeyword] = useState<Keywords | null>(null);
 
@@ -38,6 +41,7 @@ const DetailModal: FC<DetailModalProps> = ({ mediaType, setIsModalOpen }) => {
 			fetchMovieJSON();
 		} else if (mediaType === MediaType.TV) {
 			fetchTVJSON();
+			fetchEpisodes();
 		}
 	}, []);
 
@@ -58,6 +62,17 @@ const DetailModal: FC<DetailModalProps> = ({ mediaType, setIsModalOpen }) => {
 			const data = await response.json();
 			const mappedMovie = mapTV(data);
 			setVideo(mappedMovie);
+		} catch (error) {
+			console.log("Error fetch data", error);
+		}
+	};
+
+	const fetchEpisodes = async () => {
+		try {
+			const response = await fetch("../json/season.json");
+			const data = await response.json();
+			const mappedSeason = mapEpisodes(data);
+			setEpisodes(mappedSeason);
 		} catch (error) {
 			console.log("Error fetch data", error);
 		}
@@ -87,7 +102,7 @@ const DetailModal: FC<DetailModalProps> = ({ mediaType, setIsModalOpen }) => {
 
 	return (
 		<div className="presenter z-10 absolute min-h-screen">
-			{video && credit && keyword ? (
+			{video && credit && keyword && episodes ? (
 				<div className="wrapper-model fixed inset-0 bg-black bg-opacity-70 flex items-start justify-center overflow-auto">
 					<div
 						className="modal relative bg-neutral-900 w-full max-w-6xl mt-8 mx-2 rounded-lg overflow-auto"
@@ -97,8 +112,21 @@ const DetailModal: FC<DetailModalProps> = ({ mediaType, setIsModalOpen }) => {
 						<ModalPoster video={video}>
 							<ModalPosterButtons />
 						</ModalPoster>
-						<ModalInfoSummary video={video} casts={credit.cast} keywords={keyword.keywords}/>
-						<ModalInfoDetail video={video} credit={credit} keywords={keyword.keywords}/>
+						<ModalInfoSummary
+							video={video}
+							casts={credit.cast}
+							keywords={keyword.keywords}
+						/>
+						<ModalEpisodes
+							backdropPath={video.backdropPath}
+							seasons={(video as Series).seasons}
+							episodes={episodes}
+						/>
+						<ModalInfoDetail
+							video={video}
+							credit={credit}
+							keywords={keyword.keywords}
+						/>
 					</div>
 				</div>
 			) : (

--- a/src/components/DetailModal/page.tsx
+++ b/src/components/DetailModal/page.tsx
@@ -93,7 +93,7 @@ const DetailModal: FC<DetailModalProps> = ({ mediaType, setIsModalOpen }) => {
 						className="modal relative bg-neutral-900 w-full max-w-6xl mt-8 mx-2 rounded-lg overflow-auto"
 						ref={ref}
 					>
-						(<ModalHeader setIsModalOpen={setIsModalOpen} />
+						<ModalHeader setIsModalOpen={setIsModalOpen} />
 						<ModalPoster video={video}>
 							<ModalPosterButtons />
 						</ModalPoster>


### PR DESCRIPTION
# 작업내역
- 시리즈물일 때 회차에 시즌이 표기되도록 작업했습니다.
- 에피소드가 5개 넘어가면 더보기 형태로 나올 수 있도록 했습니다.(원래는 10개라서 나중에 수정예정입니다!)
- 드롭다운 버튼을 통해 시즌이 변경되도록 했습니다.
  - json은 더미라 변경되진 않지만 드롭다운 내부 텍스트는 변경됩니다.


## 스크린샷

|상단 화면|시즌드롭다운|
|--|--|
|<img width="1510" alt="스크린샷 2025-01-16 오전 1 01 03" src="https://github.com/user-attachments/assets/4bba461a-4bbb-4430-983e-fe3ab77a0c69" />|<img width="1510" alt="스크린샷 2025-01-16 오전 1 01 05" src="https://github.com/user-attachments/assets/18cbf437-93b6-427e-963f-3b1142443705" />|

|하단 화면|더보기 클릭 시|
|--|--|
|<img width="1510" alt="스크린샷 2025-01-16 오전 1 01 08" src="https://github.com/user-attachments/assets/ddf33e65-7428-46bf-8183-d2d8c2842b62" />|<img width="1510" alt="스크린샷 2025-01-16 오전 1 01 11" src="https://github.com/user-attachments/assets/6acc2663-e5ed-4006-98cc-dca264efc2b0" />|
