### PR TITLE
홈페이지 섹션 추가 구현

### DIFF
--- a/src/api/requests.ts
+++ b/src/api/requests.ts
@@ -10,8 +10,24 @@ const requests = {
   fetchDocumentaries: "/discover/movie?with_genres=99",
 
   // 홈화면에서 사용하는 부분 (위와 중복이 있을 수도 있지만 헷갈리지 않도록 이름을 다르게 했습니다.)
-  fetchNowPlayingMovies: "/movie/now_playing",
-  fetchPopularMoviesData: "/movie/popular",
+  fetchForYou: "/trending/all/day?language=ko-KR", // 회원님을 위해 엄선한 오늘의 콘텐츠
+  fetchTodayTop10Series: "/trending/tv/day", //오늘 전세계의 TOP 10 시리즈
+  //---- fetchTodayTop10SeriesKR 로 필터링된 오늘 대한민국의 TOP 10 시리즈
+
+  fetchRealitySeries:
+    "/discover/tv?include_adult=false&include_null_first_air_dates=false&language=en-US&page=1&sort_by=popularity.desc&with_genres=10764", // 재미를 주는 리얼리티 시리즈
+  fetchTopRatedSeries: "/tv/top_rated", // 평단의 찬사! 감명을 주는 시리즈
+  fetchEnglishContents:
+    "/discover/tv?include_adult=false&include_null_first_air_dates=false&sort_by=vote_average&language=ko-KR&with_original_language=en", // 즐거운 영어 세상 속으로!
+  fetchUSMovies:
+    "/discover/movie?include_adult=false&include_video=true&language=ko-KR&sort_by=popularity.desc&with_origin_country=US&without_genres=10763", // 미국 영화
+  fetchKoreanSeries:
+    "/discover/tv?include_adult=false&&include_null_first_air_dates=false&language=ko-KR&sort_by=popularity.desc&with_origin_country=KR&without_genres=10763%2C%2010768", // 한국 시리즈
+  // 시청 중인 컨텐츠
+  fetchPopularMovies: "/movie/popular", // 오늘 전세계의 TOP 10 영화
+  fetchNowPlayingMovies: "/movie/now_playing", // 지금 상영 중인 영화
+  fetchSFAndFantasySeries:
+    "/discover/tv?include_adult=false&include_null_first_air_dates=false&language=ko-KR&sort_by=popularity.desc&with_genres=10765&with_origin_country=KR&without_genres=10762", // SF &  판타지 시리즈
 };
 
 export default requests;

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -41,7 +41,7 @@ const CardList: React.FC<CardListProps> = ({ title, moviesAndSeries }) => {
         <div className="swiper-pagination" ref={paginationRef}></div>
       </div>
 
-      <div className="swiper-and-buttons relative overflow-visible w-full z-30">
+      <div className="swiper-and-buttons relative overflow-visible w-full z-5">
         <Swiper
           // allowTouchMove={true}
           loop={true}

--- a/src/components/PosterList.tsx
+++ b/src/components/PosterList.tsx
@@ -40,7 +40,7 @@ const PosterList: React.FC<PosterListProps> = ({ title, moviesAndSeries }) => {
         <div className="swiper-pagination" ref={paginationRef}></div>
       </div>
 
-      <div className="swiper-and-buttons relative overflow-visible z-30">
+      <div className="swiper-and-buttons relative overflow-visible z-5">
         <Swiper
           loop={true}
           loopAddBlankSlides={false}

--- a/src/pages/HomePage/page.tsx
+++ b/src/pages/HomePage/page.tsx
@@ -10,19 +10,37 @@ interface MovieOrSeries {
   id: number;
   backdrop_path: string;
   poster_path: string;
+  origin_country?: string[];
 }
 
 const HomePage: React.FC = () => {
-  const [nowPlayingMovies, setNowPlayingMovies] = useState<MovieOrSeries[]>([]);
+  const [forYou, setForYou] = useState<MovieOrSeries[]>([]);
+  const [todayTop10SeriesKR, setTodayTop10SeriesKR] = useState<MovieOrSeries[]>(
+    []
+  );
+  const [realitySeries, setRealitySeries] = useState<MovieOrSeries[]>([]);
+  const [topRatedSeries, setTopRatedSeries] = useState<MovieOrSeries[]>([]);
+  const [englishContents, setEnglishContents] = useState<MovieOrSeries[]>([]);
+  const [uSMovies, setUSMovies] = useState<MovieOrSeries[]>([]);
+  const [koreanSeries, setKoreanSeries] = useState<MovieOrSeries[]>([]);
   const [popularMovies, setPopularMovies] = useState<MovieOrSeries[]>([]);
+  const [nowPlayingMovies, setNowPlayingMovies] = useState<MovieOrSeries[]>([]);
+  const [sFAndFantasySeries, setSFAndFantasySeries] = useState<MovieOrSeries[]>(
+    []
+  );
 
   // fetchDataHome 컴포넌트는 fetchData로 따로 컴포넌트화 시켜서 재사용할 수 있지만
   // 각 page에서 개인 api 연결 공부를 위해 page에 넣음
   const fetchDataHome = async (url: string) => {
     try {
-      console.log("요청 URL:", url);
       const response = await instance.get(url);
-      return response.data.results;
+      const results = response.data.results;
+
+      const filteredResults = results.filter(
+        (item: any) => item.backdrop_path !== null
+      );
+
+      return filteredResults;
     } catch (error) {
       console.log("API 요청 에러", error);
       return [];
@@ -32,23 +50,144 @@ const HomePage: React.FC = () => {
   useEffect(() => {
     const fetchHome = async () => {
       try {
-				// 1페이지에 20개 라서 40개 불러올 경우 여러 페이지를 불러와야함.
-				const nowPlayingMoviePage1 = await fetchDataHome(
+        // 회원님을 위해 엄선한 오늘의 콘텐츠
+        const forYouPage1 = await fetchDataHome(
+          `${requests.fetchForYou}?page=1`
+        );
+        const forYouPage2 = await fetchDataHome(
+          `${requests.fetchForYou}?page=2`
+        );
+        const forYouPage3 = await fetchDataHome(
+          `${requests.fetchForYou}?page=3`
+        );
+
+        const forYouData = [...forYouPage1, ...forYouPage2, ...forYouPage3];
+
+        // 오늘 대한민국의 TOP 10 시리즈
+        const todayTop10SeriesData = await fetchDataHome(
+          requests.fetchTodayTop10Series
+        );
+
+        const todayTop10SeriesDataKR = todayTop10SeriesData.filter(
+          (item: MovieOrSeries) => item.origin_country?.includes("KR")
+        );
+
+        let todayTop10SeriesFinalKR: MovieOrSeries[] = [];
+        if (todayTop10SeriesDataKR.length >= 10) {
+          todayTop10SeriesFinalKR = todayTop10SeriesDataKR;
+        } else {
+          const needed = 10 - todayTop10SeriesDataKR.length;
+          const nonKrSeries = todayTop10SeriesData.filter(
+            (item: MovieOrSeries) => !item.origin_country?.includes("KR")
+          );
+          const fillOthers = nonKrSeries.slice(0, needed);
+          todayTop10SeriesFinalKR = [...todayTop10SeriesDataKR, ...fillOthers];
+        }
+
+        // 재미를 주는 리얼리티 시리즈
+        const realitySeriesPage1 = await fetchDataHome(
+          `${requests.fetchRealitySeries}?language=ko-KR&page=1`
+        );
+        const realitySeriesPage2 = await fetchDataHome(
+          `${requests.fetchRealitySeries}?language=ko-KR&page=2`
+        );
+        const realitySeriesPage3 = await fetchDataHome(
+          `${requests.fetchRealitySeries}?language=ko-KR&page=3`
+        );
+
+        const realitySeriesData = [
+          ...realitySeriesPage1,
+          ...realitySeriesPage2,
+          ...realitySeriesPage3,
+        ];
+
+        // 평단의 찬사! 감명을 주는 시리즈
+        const topRatedSeriesData = await fetchDataHome(
+          requests.fetchTopRatedSeries
+        );
+
+        // 즐거운 영어 세상 속으로!
+        const englishContentsData = await fetchDataHome(
+          requests.fetchEnglishContents
+        );
+
+        // 미국 영화
+        const uSMoviesPage1 = await fetchDataHome(
+          `${requests.fetchUSMovies}?page=1`
+        );
+        const uSMoviesPage2 = await fetchDataHome(
+          `${requests.fetchUSMovies}?page=2`
+        );
+        const uSMoviesPage3 = await fetchDataHome(
+          `${requests.fetchUSMovies}?page=3`
+        );
+
+        const uSMoviesData = [
+          ...uSMoviesPage1,
+          ...uSMoviesPage2,
+          ...uSMoviesPage3,
+        ];
+
+        // 한국 시리즈
+        const koreanSeriesPage1 = await fetchDataHome(
+          `${requests.fetchKoreanSeries}?page=1`
+        );
+        const koreanSeriesPage2 = await fetchDataHome(
+          `${requests.fetchKoreanSeries}?page=2`
+        );
+        const koreanSeriesPage3 = await fetchDataHome(
+          `${requests.fetchKoreanSeries}?page=3`
+        );
+
+        const koreanSeriesData = [
+          ...koreanSeriesPage1,
+          ...koreanSeriesPage2,
+          ...koreanSeriesPage3,
+        ];
+
+        // 오늘 전세계의 TOP 10 영화
+        const popularMoviesData = await fetchDataHome(
+          requests.fetchPopularMovies
+        );
+
+        // 지금 상영 중인 영화
+        // 1페이지에 20개 라서 40개 불러올 경우 여러 페이지를 불러와야함.
+        const nowPlayingMoviePage1 = await fetchDataHome(
           `${requests.fetchNowPlayingMovies}?language=ko-KR&page=1`
         );
         const nowPlayingMoviePage2 = await fetchDataHome(
           `${requests.fetchNowPlayingMovies}?language=ko-KR&page=2`
         );
 
-        const nowPlayingMovieData = [...nowPlayingMoviePage1, ...nowPlayingMoviePage2];
+        const nowPlayingMovieData = [
+          ...nowPlayingMoviePage1,
+          ...nowPlayingMoviePage2,
+        ];
 
-        const popularMoviesData = await fetchDataHome(
-          requests.fetchPopularMoviesData
+        // SF &  판타지 시리즈
+        const sFAndFantasySeriesPage1 = await fetchDataHome(
+          `${requests.fetchSFAndFantasySeries}?page=1`
+        );
+        const sFAndFantasySeriesPage2 = await fetchDataHome(
+          `${requests.fetchSFAndFantasySeries}?page=2`
         );
 
-        setNowPlayingMovies(nowPlayingMovieData);
-				// 1페이지에 20개인데 top10 이라 10개만 불러올 경우
+        const sFAndFantasySeriesData = [
+          ...sFAndFantasySeriesPage1,
+          ...sFAndFantasySeriesPage2,
+        ];
+
+        setForYou(forYouData);
+        setTodayTop10SeriesKR(todayTop10SeriesFinalKR.slice(0, 10));
+        setRealitySeries(realitySeriesData);
+        setTopRatedSeries(topRatedSeriesData);
+        setEnglishContents(englishContentsData);
+        setUSMovies(uSMoviesData);
+        setKoreanSeries(koreanSeriesData);
+        // 1페이지에 20개인데 top10 이라 10개만 불러올 경우
         setPopularMovies(popularMoviesData.slice(0, 10));
+        setNowPlayingMovies(nowPlayingMovieData);
+        setSFAndFantasySeries(sFAndFantasySeriesData.slice(0, 36));
       } catch (error) {
         console.log("데이터 못 가져왔지롱~", error);
       }
@@ -61,19 +200,76 @@ const HomePage: React.FC = () => {
       <div className="banner relative z-0 h-[630px]">
         <Banner />
       </div>
-      <div className="mainbody relative z-20 pb-10">
+      <div className="mainbody relative z-5 pb-10">
         <CardList
-          title="지금 상영중인 영화"
-          moviesAndSeries={nowPlayingMovies.map((movie) => ({
-            id: movie.id,
-            backdropUrl: `https://image.tmdb.org/t/p/w500${movie.backdrop_path}`,
+          title="회원님을 위해 엄선한 오늘의 콘텐츠"
+          moviesAndSeries={forYou.map((item) => ({
+            id: item.id,
+            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+          }))}
+        />
+        <PosterList
+          title="오늘 대한민국의 TOP 10 시리즈"
+          moviesAndSeries={todayTop10SeriesKR.map((item) => ({
+            id: item.id,
+            posterUrl: `https://image.tmdb.org/t/p/w500${item.poster_path}`,
+          }))}
+        />
+        <CardList
+          title="재미를 주는 리얼리티 시리즈"
+          moviesAndSeries={realitySeries.map((item) => ({
+            id: item.id,
+            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+          }))}
+        />
+        <CardList
+          title="평단의 찬사! 감명을 주는 시리즈"
+          moviesAndSeries={topRatedSeries.map((item) => ({
+            id: item.id,
+            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+          }))}
+        />
+        <CardList
+          title="즐거운 영어 세상 속으로!"
+          moviesAndSeries={englishContents.map((item) => ({
+            id: item.id,
+            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+          }))}
+        />
+        <CardList
+          title="미국 영화"
+          moviesAndSeries={uSMovies.map((item) => ({
+            id: item.id,
+            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+          }))}
+        />
+
+        <CardList
+          title="한국 시리즈"
+          moviesAndSeries={koreanSeries.map((item) => ({
+            id: item.id,
+            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
           }))}
         />
         <PosterList
           title="오늘 전세계의 TOP 10 영화"
-          moviesAndSeries={popularMovies.map((movie) => ({
-            id: movie.id,
-            posterUrl: `https://image.tmdb.org/t/p/w500${movie.poster_path}`,
+          moviesAndSeries={popularMovies.map((item) => ({
+            id: item.id,
+            posterUrl: `https://image.tmdb.org/t/p/w500${item.poster_path}`,
+          }))}
+        />
+        <CardList
+          title="지금 상영중인 영화"
+          moviesAndSeries={nowPlayingMovies.map((item) => ({
+            id: item.id,
+            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+          }))}
+        />
+        <CardList
+          title="SF & 판타지 시리즈"
+          moviesAndSeries={sFAndFantasySeries.map((item) => ({
+            id: item.id,
+            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
           }))}
         />
       </div>

--- a/src/pages/HomePage/page.tsx
+++ b/src/pages/HomePage/page.tsx
@@ -36,6 +36,7 @@ const HomePage: React.FC = () => {
       const response = await instance.get(url);
       const results = response.data.results;
 
+			// backdrop_path가 없는 부분 filtering
       const filteredResults = results.filter(
         (item: any) => item.backdrop_path !== null
       );

--- a/src/pages/HomePage/page.tsx
+++ b/src/pages/HomePage/page.tsx
@@ -10,37 +10,19 @@ interface MovieOrSeries {
   id: number;
   backdrop_path: string;
   poster_path: string;
-  origin_country?: string[];
 }
 
 const HomePage: React.FC = () => {
-  const [forYou, setForYou] = useState<MovieOrSeries[]>([]);
-  const [todayTop10SeriesKR, setTodayTop10SeriesKR] = useState<MovieOrSeries[]>(
-    []
-  );
-  const [realitySeries, setRealitySeries] = useState<MovieOrSeries[]>([]);
-  const [topRatedSeries, setTopRatedSeries] = useState<MovieOrSeries[]>([]);
-  const [englishContents, setEnglishContents] = useState<MovieOrSeries[]>([]);
-  const [uSMovies, setUSMovies] = useState<MovieOrSeries[]>([]);
-  const [koreanSeries, setKoreanSeries] = useState<MovieOrSeries[]>([]);
-  const [popularMovies, setPopularMovies] = useState<MovieOrSeries[]>([]);
   const [nowPlayingMovies, setNowPlayingMovies] = useState<MovieOrSeries[]>([]);
-  const [sFAndFantasySeries, setSFAndFantasySeries] = useState<MovieOrSeries[]>(
-    []
-  );
+  const [popularMovies, setPopularMovies] = useState<MovieOrSeries[]>([]);
 
   // fetchDataHome 컴포넌트는 fetchData로 따로 컴포넌트화 시켜서 재사용할 수 있지만
   // 각 page에서 개인 api 연결 공부를 위해 page에 넣음
   const fetchDataHome = async (url: string) => {
     try {
+      console.log("요청 URL:", url);
       const response = await instance.get(url);
-      const results = response.data.results;
-
-      const filteredResults = results.filter(
-        (item: any) => item.backdrop_path !== null
-      );
-
-      return filteredResults;
+      return response.data.results;
     } catch (error) {
       console.log("API 요청 에러", error);
       return [];
@@ -50,144 +32,23 @@ const HomePage: React.FC = () => {
   useEffect(() => {
     const fetchHome = async () => {
       try {
-        // 회원님을 위해 엄선한 오늘의 콘텐츠
-        const forYouPage1 = await fetchDataHome(
-          `${requests.fetchForYou}?page=1`
-        );
-        const forYouPage2 = await fetchDataHome(
-          `${requests.fetchForYou}?page=2`
-        );
-        const forYouPage3 = await fetchDataHome(
-          `${requests.fetchForYou}?page=3`
-        );
-
-        const forYouData = [...forYouPage1, ...forYouPage2, ...forYouPage3];
-
-        // 오늘 대한민국의 TOP 10 시리즈
-        const todayTop10SeriesData = await fetchDataHome(
-          requests.fetchTodayTop10Series
-        );
-
-        const todayTop10SeriesDataKR = todayTop10SeriesData.filter(
-          (item: MovieOrSeries) => item.origin_country?.includes("KR")
-        );
-
-        let todayTop10SeriesFinalKR: MovieOrSeries[] = [];
-        if (todayTop10SeriesDataKR.length >= 10) {
-          todayTop10SeriesFinalKR = todayTop10SeriesDataKR;
-        } else {
-          const needed = 10 - todayTop10SeriesDataKR.length;
-          const nonKrSeries = todayTop10SeriesData.filter(
-            (item: MovieOrSeries) => !item.origin_country?.includes("KR")
-          );
-          const fillOthers = nonKrSeries.slice(0, needed);
-          todayTop10SeriesFinalKR = [...todayTop10SeriesDataKR, ...fillOthers];
-        }
-
-        // 재미를 주는 리얼리티 시리즈
-        const realitySeriesPage1 = await fetchDataHome(
-          `${requests.fetchRealitySeries}?language=ko-KR&page=1`
-        );
-        const realitySeriesPage2 = await fetchDataHome(
-          `${requests.fetchRealitySeries}?language=ko-KR&page=2`
-        );
-        const realitySeriesPage3 = await fetchDataHome(
-          `${requests.fetchRealitySeries}?language=ko-KR&page=3`
-        );
-
-        const realitySeriesData = [
-          ...realitySeriesPage1,
-          ...realitySeriesPage2,
-          ...realitySeriesPage3,
-        ];
-
-        // 평단의 찬사! 감명을 주는 시리즈
-        const topRatedSeriesData = await fetchDataHome(
-          requests.fetchTopRatedSeries
-        );
-
-        // 즐거운 영어 세상 속으로!
-        const englishContentsData = await fetchDataHome(
-          requests.fetchEnglishContents
-        );
-
-        // 미국 영화
-        const uSMoviesPage1 = await fetchDataHome(
-          `${requests.fetchUSMovies}?page=1`
-        );
-        const uSMoviesPage2 = await fetchDataHome(
-          `${requests.fetchUSMovies}?page=2`
-        );
-        const uSMoviesPage3 = await fetchDataHome(
-          `${requests.fetchUSMovies}?page=3`
-        );
-
-        const uSMoviesData = [
-          ...uSMoviesPage1,
-          ...uSMoviesPage2,
-          ...uSMoviesPage3,
-        ];
-
-        // 한국 시리즈
-        const koreanSeriesPage1 = await fetchDataHome(
-          `${requests.fetchKoreanSeries}?page=1`
-        );
-        const koreanSeriesPage2 = await fetchDataHome(
-          `${requests.fetchKoreanSeries}?page=2`
-        );
-        const koreanSeriesPage3 = await fetchDataHome(
-          `${requests.fetchKoreanSeries}?page=3`
-        );
-
-        const koreanSeriesData = [
-          ...koreanSeriesPage1,
-          ...koreanSeriesPage2,
-          ...koreanSeriesPage3,
-        ];
-
-        // 오늘 전세계의 TOP 10 영화
-        const popularMoviesData = await fetchDataHome(
-          requests.fetchPopularMovies
-        );
-
-        // 지금 상영 중인 영화
-        // 1페이지에 20개 라서 40개 불러올 경우 여러 페이지를 불러와야함.
-        const nowPlayingMoviePage1 = await fetchDataHome(
+				// 1페이지에 20개 라서 40개 불러올 경우 여러 페이지를 불러와야함.
+				const nowPlayingMoviePage1 = await fetchDataHome(
           `${requests.fetchNowPlayingMovies}?language=ko-KR&page=1`
         );
         const nowPlayingMoviePage2 = await fetchDataHome(
           `${requests.fetchNowPlayingMovies}?language=ko-KR&page=2`
         );
 
-        const nowPlayingMovieData = [
-          ...nowPlayingMoviePage1,
-          ...nowPlayingMoviePage2,
-        ];
+        const nowPlayingMovieData = [...nowPlayingMoviePage1, ...nowPlayingMoviePage2];
 
-        // SF &  판타지 시리즈
-        const sFAndFantasySeriesPage1 = await fetchDataHome(
-          `${requests.fetchSFAndFantasySeries}?page=1`
-        );
-        const sFAndFantasySeriesPage2 = await fetchDataHome(
-          `${requests.fetchSFAndFantasySeries}?page=2`
+        const popularMoviesData = await fetchDataHome(
+          requests.fetchPopularMoviesData
         );
 
-        const sFAndFantasySeriesData = [
-          ...sFAndFantasySeriesPage1,
-          ...sFAndFantasySeriesPage2,
-        ];
-
-        setForYou(forYouData);
-        setTodayTop10SeriesKR(todayTop10SeriesFinalKR.slice(0, 10));
-        setRealitySeries(realitySeriesData);
-        setTopRatedSeries(topRatedSeriesData);
-        setEnglishContents(englishContentsData);
-        setUSMovies(uSMoviesData);
-        setKoreanSeries(koreanSeriesData);
-        // 1페이지에 20개인데 top10 이라 10개만 불러올 경우
-        setPopularMovies(popularMoviesData.slice(0, 10));
         setNowPlayingMovies(nowPlayingMovieData);
-        setSFAndFantasySeries(sFAndFantasySeriesData.slice(0, 36));
+				// 1페이지에 20개인데 top10 이라 10개만 불러올 경우
+        setPopularMovies(popularMoviesData.slice(0, 10));
       } catch (error) {
         console.log("데이터 못 가져왔지롱~", error);
       }
@@ -200,76 +61,19 @@ const HomePage: React.FC = () => {
       <div className="banner relative z-0 h-[630px]">
         <Banner />
       </div>
-      <div className="mainbody relative z-5 pb-10">
+      <div className="mainbody relative z-20 pb-10">
         <CardList
-          title="회원님을 위해 엄선한 오늘의 콘텐츠"
-          moviesAndSeries={forYou.map((item) => ({
-            id: item.id,
-            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
-          }))}
-        />
-        <PosterList
-          title="오늘 대한민국의 TOP 10 시리즈"
-          moviesAndSeries={todayTop10SeriesKR.map((item) => ({
-            id: item.id,
-            posterUrl: `https://image.tmdb.org/t/p/w500${item.poster_path}`,
-          }))}
-        />
-        <CardList
-          title="재미를 주는 리얼리티 시리즈"
-          moviesAndSeries={realitySeries.map((item) => ({
-            id: item.id,
-            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
-          }))}
-        />
-        <CardList
-          title="평단의 찬사! 감명을 주는 시리즈"
-          moviesAndSeries={topRatedSeries.map((item) => ({
-            id: item.id,
-            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
-          }))}
-        />
-        <CardList
-          title="즐거운 영어 세상 속으로!"
-          moviesAndSeries={englishContents.map((item) => ({
-            id: item.id,
-            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
-          }))}
-        />
-        <CardList
-          title="미국 영화"
-          moviesAndSeries={uSMovies.map((item) => ({
-            id: item.id,
-            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
-          }))}
-        />
-
-        <CardList
-          title="한국 시리즈"
-          moviesAndSeries={koreanSeries.map((item) => ({
-            id: item.id,
-            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+          title="지금 상영중인 영화"
+          moviesAndSeries={nowPlayingMovies.map((movie) => ({
+            id: movie.id,
+            backdropUrl: `https://image.tmdb.org/t/p/w500${movie.backdrop_path}`,
           }))}
         />
         <PosterList
           title="오늘 전세계의 TOP 10 영화"
-          moviesAndSeries={popularMovies.map((item) => ({
-            id: item.id,
-            posterUrl: `https://image.tmdb.org/t/p/w500${item.poster_path}`,
-          }))}
-        />
-        <CardList
-          title="지금 상영중인 영화"
-          moviesAndSeries={nowPlayingMovies.map((item) => ({
-            id: item.id,
-            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
-          }))}
-        />
-        <CardList
-          title="SF & 판타지 시리즈"
-          moviesAndSeries={sFAndFantasySeries.map((item) => ({
-            id: item.id,
-            backdropUrl: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+          moviesAndSeries={popularMovies.map((movie) => ({
+            id: movie.id,
+            posterUrl: `https://image.tmdb.org/t/p/w500${movie.poster_path}`,
           }))}
         />
       </div>


### PR DESCRIPTION
## 작업내역
#### 공통사항
- 카드 리스트와 포스터 리스트의 z index가 네비바(유지) 보다 커서 위로 올라오는 코드 수정했습니다.
#### 홈화면 페이지
- API 데이터 연결 및 각색한 홈 화면 섹션 구현
    - ForYou, 오늘 TOP 10 시리즈KR, 리얼리티 시리즈, 감명 시리즈, 영어 컨텐츠, 미국영화, 한국시리즈, 전세계 TOP 10 영화, 지금 상영 중인 영화, SF & 판타지 섹션 추가
## 스크린샷
![image](https://github.com/user-attachments/assets/a86c8411-ac62-42d8-becf-6fb9ef7a0d2a)


### 하고 싶은 말
커밋을.. 나눴어야 하는데 깜빡했습니다. <br />
시도 하려고 commit revert도 했으나 도저히 한땀한땀 못할 것 같아서 그냥 올리게 되었습니다. <br/>
앞으로 반성하고 시정 하겠습니다. 주석에 신중을 가했습니다. 또, TIL에 구체적으로 작성 해놓겠습니다.🥺 