### PR TITLE
더미 디테일 카드 추가로 기능 구현

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 
-interface CardProps {
+export interface CardProps {
 	id: number;
-	backdropPath: string;
+	backdrop_path: string;
 }
 
-const Card: React.FC<CardProps> = ({ backdropPath }) => {
+const Card: React.FC<CardProps> = ({ backdrop_path }) => {
   return (
     <div className="relative">
       <img
-        src={backdropPath}
+        src={backdrop_path}
         alt=""
         className="h-auto object-cover rounded-sm"
       />

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import { MediaType } from "../models/Media";
 
 export interface CardProps {
 	id: number;
 	backdrop_path: string;
+	type: MediaType;
 }
 
 

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -131,13 +131,14 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
                 }
               }}
             >
-              <Card id={item.id} backdrop_path={item.backdrop_path} />
+              <Card id={item.id} backdrop_path={item.backdrop_path} type={item.type}/>
             </SwiperSlide>
           ))}
         </Swiper>
         {/* 디테일 카드 호버 */}
         {hoveredItem && hoverPosition && (
           <DummyDetailCard
+						type={hoveredItem.type}
             id={hoveredItem.id}
             backdrop_path={hoveredItem.backdrop_path}
             style={{

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -1,5 +1,5 @@
-import React, { useRef } from "react";
-import Card from "./Card";
+import React, { useRef, useState } from "react";
+import Card, { CardProps } from "./Card";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import "swiper/css/navigation";
@@ -9,15 +9,16 @@ import { Navigation, Pagination } from "swiper/modules";
 import { Swiper as SwiperType } from "swiper";
 
 import "../styles/swiper.css";
+import DummyDetailCard from "./__DummyDetailCard";
 
-interface CardProps {
-	id: number;
-	backdrop_path: string;
+interface HoverPosition {
+  top: number;
+  left: number;
 }
 
 interface CardListProps {
-	title: string;
-	cardProps: CardProps[];
+  title: string;
+  cardProps: CardProps[];
 }
 
 const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
@@ -34,13 +35,37 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
     },
   };
 
+  // 디테일 카드 호버 부분
+  const [hoveredItem, setHoveredItem] = useState<CardProps | null>(null);
+  const [hoverPosition, setHoverPosition] = useState<HoverPosition | null>(
+    null
+  );
+
+  const handleCardMouseEnter = (item: CardProps, rect: DOMRect) => {
+    setHoveredItem(item);
+    setHoverPosition({
+      top: rect.top,
+      left: rect.left,
+    });
+  };
+
+  const handleDetailMouseEnter = () => {
+    // 디테일 카드로 마우스 이동시 아무 효과 없음
+  };
+
+  const handleDetailMouseLeave = () => {
+    setHoveredItem(null);
+    setHoverPosition(null);
+  };
+
   return (
     <section className="cardList my-6 mx-12 overflow-visible">
+			{/* 타이틀, 페이지네이션*/}
       <div className="title-and-pagination relative flex flex-row justify-between mb-1">
         <h2 className="text-l font-bold left-2">{title}</h2>
         <div className="swiper-pagination" ref={paginationRef}></div>
       </div>
-
+			{/* 스와이퍼 */}
       <div className="swiper-and-buttons relative overflow-visible w-full z-5">
         <Swiper
           // allowTouchMove={true}
@@ -87,20 +112,31 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
             },
           }}
         >
-          {cardProps.map((item) => (
-            <SwiperSlide >
-              <Card id={item.id} backdropPath={item.backdrop_path} />
+          {cardProps.map((item, index) => (
+            <SwiperSlide
+              onMouseEnter={(event) => {
+                const rect = (
+                  event.currentTarget as HTMLElement
+                ).getBoundingClientRect();
+                handleCardMouseEnter(item, rect);
+              }}
+              onMouseLeave={() => {
+                if (!hoveredItem) {
+                  setHoveredItem(null);
+                }
+              }}
+            >
+              <Card id={item.id} backdrop_path={item.backdrop_path} />
             </SwiperSlide>
           ))}
         </Swiper>
-        <div>
-          <button
-            ref={prevRef}
-            className="absolute top-1/2 -left-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70  hover:text-4xl focus:outline-none z-50"
-          >
-            <i className="fas fa-chevron-left text-2xl hover:opacity-100"></i>
-          </button>
-        </div>
+				{/* 양쪽 버튼 */}
+        <button
+          ref={prevRef}
+          className="absolute top-1/2 -left-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70  hover:text-4xl focus:outline-none z-50"
+        >
+          <i className="fas fa-chevron-left text-2xl hover:opacity-100"></i>
+        </button>
         <button
           ref={nextRef}
           className="absolute top-1/2 -right-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70 hover:text-4xl  focus:outline-none z-50"
@@ -108,6 +144,22 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
           <i className="fas fa-chevron-right text-2xl hover:opacity-100"></i>
         </button>
       </div>
+			{/* 디테일 카드 호버 */}
+      {hoveredItem && hoverPosition && (
+        <DummyDetailCard
+          id={hoveredItem.id}
+          backdrop_path={hoveredItem.backdrop_path}
+          style={{
+            position: "absolute",
+            top: hoverPosition.top - 180,
+            left: hoverPosition.left - 20,
+
+            zIndex: 7,
+          }}
+          onMouseEnter={handleDetailMouseEnter}
+          onMouseLeave={handleDetailMouseLeave}
+        />
+      )}
     </section>
   );
 };

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -42,10 +42,13 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
   );
 
   const handleCardMouseEnter = (item: CardProps, rect: DOMRect) => {
+    console.log("Card BoundingClientRect:", rect);
+    console.log("scroll:", window.scrollY);
+
     setHoveredItem(item);
     setHoverPosition({
-      top: rect.top,
-      left: rect.left,
+      top: rect.top + window.scrollY,
+      left: rect.left + rect.width / 2,
     });
   };
 
@@ -60,12 +63,12 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
 
   return (
     <section className="cardList my-6 mx-12 overflow-visible">
-			{/* 타이틀, 페이지네이션*/}
+      {/* 타이틀, 페이지네이션*/}
       <div className="title-and-pagination relative flex flex-row justify-between mb-1">
         <h2 className="text-l font-bold left-2">{title}</h2>
         <div className="swiper-pagination" ref={paginationRef}></div>
       </div>
-			{/* 스와이퍼 */}
+      {/* 스와이퍼 */}
       <div className="swiper-and-buttons relative overflow-visible w-full z-5">
         <Swiper
           // allowTouchMove={true}
@@ -114,6 +117,8 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
         >
           {cardProps.map((item, index) => (
             <SwiperSlide
+              key={`${item.id}-${index}`}
+              style={{ position: "relative", zIndex: 1 }}
               onMouseEnter={(event) => {
                 const rect = (
                   event.currentTarget as HTMLElement
@@ -130,36 +135,36 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
             </SwiperSlide>
           ))}
         </Swiper>
-				{/* 양쪽 버튼 */}
+        {/* 디테일 카드 호버 */}
+        {hoveredItem && hoverPosition && (
+          <DummyDetailCard
+            id={hoveredItem.id}
+            backdrop_path={hoveredItem.backdrop_path}
+            style={{
+              position: "absolute",
+              top: "cal(hoverPosition.top - scrollY)",
+              left: hoverPosition.left,
+              transform: "translate(-75%, -60%)",
+              zIndex: 7,
+            }}
+            onMouseEnter={handleDetailMouseEnter}
+            onMouseLeave={handleDetailMouseLeave}
+          />
+        )}
+        {/* 양쪽 버튼 */}
         <button
           ref={prevRef}
-          className="absolute top-1/2 -left-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70  hover:text-4xl focus:outline-none z-50"
+          className="absolute top-1/2 -left-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70  hover:text-4xl focus:outline-none z-5"
         >
           <i className="fas fa-chevron-left text-2xl hover:opacity-100"></i>
         </button>
         <button
           ref={nextRef}
-          className="absolute top-1/2 -right-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70 hover:text-4xl  focus:outline-none z-50"
+          className="absolute top-1/2 -right-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70 hover:text-4xl  focus:outline-none z-5"
         >
           <i className="fas fa-chevron-right text-2xl hover:opacity-100"></i>
         </button>
       </div>
-			{/* 디테일 카드 호버 */}
-      {hoveredItem && hoverPosition && (
-        <DummyDetailCard
-          id={hoveredItem.id}
-          backdrop_path={hoveredItem.backdrop_path}
-          style={{
-            position: "absolute",
-            top: hoverPosition.top - 180,
-            left: hoverPosition.left - 20,
-
-            zIndex: 7,
-          }}
-          onMouseEnter={handleDetailMouseEnter}
-          onMouseLeave={handleDetailMouseLeave}
-        />
-      )}
     </section>
   );
 };

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -147,6 +147,7 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
               transform: "translate(-75%, -60%)",
               zIndex: 10,
             }}
+						isActive={true}
             onMouseEnter={handleDetailMouseEnter}
             onMouseLeave={handleDetailMouseLeave}
           />

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -118,7 +118,7 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
           {cardProps.map((item, index) => (
             <SwiperSlide
               key={`${item.id}-${index}`}
-              style={{ position: "relative", zIndex: 1 }}
+              style={{ position: "relative" }}
               onMouseEnter={(event) => {
                 const rect = (
                   event.currentTarget as HTMLElement
@@ -145,7 +145,7 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
               top: "cal(hoverPosition.top - scrollY)",
               left: hoverPosition.left,
               transform: "translate(-75%, -60%)",
-              zIndex: 7,
+              zIndex: 10,
             }}
             onMouseEnter={handleDetailMouseEnter}
             onMouseLeave={handleDetailMouseLeave}
@@ -154,13 +154,13 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
         {/* 양쪽 버튼 */}
         <button
           ref={prevRef}
-          className="absolute top-1/2 -left-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70  hover:text-4xl focus:outline-none z-5"
+          className="absolute top-1/2 -left-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70  hover:text-4xl focus:outline-none z-20"
         >
           <i className="fas fa-chevron-left text-2xl hover:opacity-100"></i>
         </button>
         <button
           ref={nextRef}
-          className="absolute top-1/2 -right-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70 hover:text-4xl  focus:outline-none z-5"
+          className="absolute top-1/2 -right-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70 hover:text-4xl  focus:outline-none z-20"
         >
           <i className="fas fa-chevron-right text-2xl hover:opacity-100"></i>
         </button>

--- a/src/components/Poster.tsx
+++ b/src/components/Poster.tsx
@@ -1,11 +1,17 @@
 import React from "react";
 import { Rank } from "../models/Media";
 
-interface PosterProps extends Rank {
-	poster_path: string;
+export interface PosterProps extends Rank {
+  id: number;
+  poster_path: string;
+  backdrop_path: string;
 }
 
-const Poster: React.FC<PosterProps> = ({ poster_path, rank }) => {
+const Poster: React.FC<PosterProps> = ({
+  poster_path,
+  backdrop_path,
+  rank,
+}) => {
   const renderRankSVG = () => {
     switch (rank) {
       case 1:

--- a/src/components/Poster.tsx
+++ b/src/components/Poster.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { Rank } from "../models/Media";
+import { MediaType, Rank } from "../models/Media";
 
 export interface PosterProps extends Rank {
   id: number;
   poster_path: string;
   backdrop_path: string;
+	type: MediaType;
 }
 
 const Poster: React.FC<PosterProps> = ({

--- a/src/components/PosterList.tsx
+++ b/src/components/PosterList.tsx
@@ -156,6 +156,7 @@ const PosterList: React.FC<PosterListProps> = ({ title, posterProps }) => {
               transform: "translate(-75%, -70%)",
               zIndex: 10,
             }}
+						isActive={true}
             onMouseEnter={handleDetailMouseEnter}
             onMouseLeave={handleDetailMouseLeave}
           />

--- a/src/components/PosterList.tsx
+++ b/src/components/PosterList.tsx
@@ -9,17 +9,11 @@ import { Swiper as SwiperType } from "swiper";
 import "../styles/swiper.css";
 import { CardProps } from "./Card";
 import DummyDetailCard from "./__DummyDetailCard";
-import Poster from "./Poster";
+import Poster, { PosterProps } from "./Poster";
 
 interface HoverPosition {
   top: number;
   left: number;
-}
-
-export interface PosterProps {
-  id: number;
-  poster_path: string;
-  backdrop_path: string;
 }
 
 interface PosterListProps {
@@ -137,6 +131,7 @@ const PosterList: React.FC<PosterListProps> = ({ title, posterProps }) => {
             >
               <Poster
                 id={item.id}
+								type={item.type}
                 poster_path={item.poster_path}
                 backdrop_path={item.backdrop_path}
                 rank={index + 1}
@@ -147,6 +142,7 @@ const PosterList: React.FC<PosterListProps> = ({ title, posterProps }) => {
         {/* 디테일 카드 호버 */}
         {hoveredItem && hoverPosition && (
           <DummyDetailCard
+						type={hoveredItem.type}
             id={hoveredItem.id}
             backdrop_path={hoveredItem.backdrop_path}
             style={{

--- a/src/components/PosterList.tsx
+++ b/src/components/PosterList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import "swiper/css";
 import "swiper/css/navigation";
@@ -6,19 +6,26 @@ import "swiper/css/pagination";
 import { Navigation, Pagination } from "swiper/modules";
 import { Swiper as SwiperType } from "swiper";
 
-import Poster from "./Poster";
 import "../styles/swiper.css";
+import { CardProps } from "./Card";
+import DummyDetailCard from "./__DummyDetailCard";
+import Poster from "./Poster";
 
-interface PosterProps {
-	id: number;
-	poster_path: string;
+interface HoverPosition {
+  top: number;
+  left: number;
+}
+
+export interface PosterProps {
+  id: number;
+  poster_path: string;
+  backdrop_path: string;
 }
 
 interface PosterListProps {
-	title: string;
-	posterProps: PosterProps[];
+  title: string;
+  posterProps: PosterProps[];
 }
-
 
 const PosterList: React.FC<PosterListProps> = ({ title, posterProps }) => {
   const prevRef = useRef<HTMLButtonElement | null>(null);
@@ -32,6 +39,32 @@ const PosterList: React.FC<PosterListProps> = ({ title, posterProps }) => {
         <span class="${className}"></span>
       `;
     },
+  };
+
+  // 디테일 카드 호버 부분
+  const [hoveredItem, setHoveredItem] = useState<CardProps | null>(null);
+  const [hoverPosition, setHoverPosition] = useState<HoverPosition | null>(
+    null
+  );
+
+  const handleCardMouseEnter = (item: CardProps, rect: DOMRect) => {
+    console.log("Card BoundingClientRect:", rect);
+    console.log("scroll:", window.scrollY);
+
+    setHoveredItem(item);
+    setHoverPosition({
+      top: rect.top + window.scrollY,
+      left: rect.left + rect.width / 2,
+    });
+  };
+
+  const handleDetailMouseEnter = () => {
+    // 디테일 카드로 마우스 이동시 아무 효과 없음
+  };
+
+  const handleDetailMouseLeave = () => {
+    setHoveredItem(null);
+    setHoverPosition(null);
   };
 
   return (
@@ -87,22 +120,56 @@ const PosterList: React.FC<PosterListProps> = ({ title, posterProps }) => {
           }}
         >
           {posterProps.map((item, index) => (
-            <SwiperSlide >
-              <Poster id={item.id} poster_path={item.poster_path} rank={index + 1} />
+            <SwiperSlide
+              key={`${item.id}-${index}`}
+              style={{ position: "relative" }}
+              onMouseEnter={(event) => {
+                const rect = (
+                  event.currentTarget as HTMLElement
+                ).getBoundingClientRect();
+                handleCardMouseEnter(item, rect);
+              }}
+              onMouseLeave={() => {
+                if (!hoveredItem) {
+                  setHoveredItem(null);
+                }
+              }}
+            >
+              <Poster
+                id={item.id}
+                poster_path={item.poster_path}
+                backdrop_path={item.backdrop_path}
+                rank={index + 1}
+              />
             </SwiperSlide>
           ))}
         </Swiper>
-        <div>
-          <button
-            ref={prevRef}
-            className="absolute top-1/2 -left-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70  hover:text-4xl focus:outline-none z-50"
-          >
-            <i className="fas fa-chevron-left text-2xl hover:opacity-100"></i>
-          </button>
-        </div>
+        {/* 디테일 카드 호버 */}
+        {hoveredItem && hoverPosition && (
+          <DummyDetailCard
+            id={hoveredItem.id}
+            backdrop_path={hoveredItem.backdrop_path}
+            style={{
+              position: "absolute",
+              top: "cal(hoverPosition.top - scrollY)",
+              left: hoverPosition.left,
+              transform: "translate(-75%, -70%)",
+              zIndex: 10,
+            }}
+            onMouseEnter={handleDetailMouseEnter}
+            onMouseLeave={handleDetailMouseLeave}
+          />
+        )}
+        {/* 양쪽 버튼 */}
+        <button
+          ref={prevRef}
+          className="absolute top-1/2 -left-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70  hover:text-4xl focus:outline-none z-20"
+        >
+          <i className="fas fa-chevron-left text-2xl hover:opacity-100"></i>
+        </button>
         <button
           ref={nextRef}
-          className="absolute top-1/2 -right-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70 hover:text-4xl  focus:outline-none z-50"
+          className="absolute top-1/2 -right-12 transform -translate-y-1/2 h-full p-2 px-[0.9rem] rounded-s-s bg-black opacity-0 text-white hover:opacity-70 hover:text-4xl  focus:outline-none z-20"
         >
           <i className="fas fa-chevron-right text-2xl hover:opacity-100"></i>
         </button>

--- a/src/components/__DummyDetailCard.tsx
+++ b/src/components/__DummyDetailCard.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+interface DummyDetailCardProps {
+	id: number;
+	backdrop_path: string;
+	style: React.CSSProperties;
+	onMouseEnter?: () => void;
+  onMouseLeave?: () => void; 
+}
+
+const DummyDetailCard: React.FC<DummyDetailCardProps> = ({ backdrop_path, style,  onMouseEnter,
+  onMouseLeave,}) => {
+  return (
+    // 기존 w=256 h=318px
+    <div className="dummy-detail-card w-64 h-80 rounded-md bg-white text-black overflow-hidden
+        absolute z-50 opacity-0 scale-1 transition-all duration-500 ease-in-out hover:opacity-100 hover:scale-100" style={style}
+				onMouseEnter={onMouseEnter} // 디테일 카드 유지
+      	onMouseLeave={onMouseLeave}
+			>
+					
+					{/*  */}
+      <div className="dummy-detail-card-backdrop w-64 h-36">
+        <img className="w-full h-full object-cover"
+          src={backdrop_path}
+          alt=""
+        />
+      </div>
+      {/* 원래 h=174px */}
+      <div className="dummy-detail-card-contents w-64 h-44 p-4">
+        <button className="w-6 h-6 flex items-center justify-center rounded-full border-2 border-gray-300 hover:bg-gray-100">
+          <svg
+            width="80px"
+            height="80px"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect width="24" height="24" fill="none" />
+            <path
+              d="M12 6V18"
+              stroke="#000000"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M6 12H18"
+              stroke="#000000"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DummyDetailCard;

--- a/src/components/__DummyDetailCard.tsx
+++ b/src/components/__DummyDetailCard.tsx
@@ -1,26 +1,59 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 interface DummyDetailCardProps {
-	id: number;
-	backdrop_path: string;
-	style: React.CSSProperties;
-	onMouseEnter?: () => void;
-  onMouseLeave?: () => void; 
+  id: number;
+  backdrop_path: string;
+  style: React.CSSProperties;
+  isActive: boolean;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+  onClick?: () => void;
 }
 
-const DummyDetailCard: React.FC<DummyDetailCardProps> = ({ backdrop_path, style,  onMouseEnter,
-  onMouseLeave,}) => {
+const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
+  backdrop_path,
+  style,
+  isActive,
+  onMouseEnter,
+  onMouseLeave,
+  onClick,
+}) => {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    // id(backdrop_path) 변경 시 즉시 숨김
+    setVisible(false);
+
+    // isActive가 true일 때 약간의 딜레이 후 보이도록 설정
+    if (isActive) {
+      const timeout = setTimeout(() => setVisible(true), 1000);
+      return () => clearTimeout(timeout);
+    }
+  }, [backdrop_path, isActive]);
+
+  const navigate = useNavigate();
+
+  const handleClickCard = () => {
+    // navigate("/movie/1241982");
+    navigate("/tv/1408");
+  };
+
   return (
     // 기존 w=256 h=318px
-    <div className="dummy-detail-card w-64 h-80 rounded-md bg-white text-black overflow-hidden
-        absolute z-50 opacity-0 scale-1 transition-all duration-500 ease-in-out hover:opacity-100 hover:scale-100" style={style}
-				onMouseEnter={onMouseEnter} // 디테일 카드 유지
-      	onMouseLeave={onMouseLeave}
-			>
-					
-					{/*  */}
+    <div
+      className={`dummy-detail-card w-64 h-80 rounded-md bg-white text-black overflow-hidden absolute z-10 transition-all duration-500  
+        ${visible ? "opacity-100 scale-100" : "opacity-0 scale-0"}`}
+      style={style}
+      onMouseEnter={onMouseEnter} // 디테일 카드 유지
+      onMouseLeave={onMouseLeave}
+      onClick={(e) => {
+        e.stopPropagation(); // 이벤트 버블링 방지
+        handleClickCard();
+      }}
+    >
       <div className="dummy-detail-card-backdrop w-64 h-36">
-        <img className="w-full h-full object-cover"
+        <img
+          className="w-full h-full object-cover"
           src={backdrop_path}
           alt=""
         />

--- a/src/components/__DummyDetailCard.tsx
+++ b/src/components/__DummyDetailCard.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { MediaType } from "../models/Media";
 
 interface DummyDetailCardProps {
+  type: MediaType;
   id: number;
   backdrop_path: string;
   style: React.CSSProperties;
@@ -12,6 +14,7 @@ interface DummyDetailCardProps {
 }
 
 const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
+  type,
   backdrop_path,
   style,
   isActive,

--- a/src/pages/HomePage/page.tsx
+++ b/src/pages/HomePage/page.tsx
@@ -210,6 +210,7 @@ const HomePage: React.FC = () => {
           posterProps={todayTop10SeriesKR.map((item) => ({
             id: item.id,
             poster_path: `https://image.tmdb.org/t/p/w500${item.poster_path}`,
+            backdrop_path: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
           }))}
         />
         <CardList
@@ -253,6 +254,7 @@ const HomePage: React.FC = () => {
           posterProps={popularMovies.map((item) => ({
             id: item.id,
             poster_path: `https://image.tmdb.org/t/p/w500${item.poster_path}`,
+            backdrop_path: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
           }))}
         />
         <CardList

--- a/src/pages/HomePage/page.tsx
+++ b/src/pages/HomePage/page.tsx
@@ -6,18 +6,16 @@ import instance from "../../api/axios";
 import PosterList from "../../components/PosterList";
 
 interface HomeMedia {
-	id: number;
-	title: string;
-	backdrop_path: string;
-	poster_path: string;
-	origin_country: string[];
+  id: number;
+  title: string;
+  backdrop_path: string;
+  poster_path: string;
+  origin_country: string[];
 }
 
 const HomePage: React.FC = () => {
   const [forYou, setForYou] = useState<HomeMedia[]>([]);
-  const [todayTop10SeriesKR, setTodayTop10SeriesKR] = useState<HomeMedia[]>(
-    []
-  );
+  const [todayTop10SeriesKR, setTodayTop10SeriesKR] = useState<HomeMedia[]>([]);
   const [realitySeries, setRealitySeries] = useState<HomeMedia[]>([]);
   const [topRatedSeries, setTopRatedSeries] = useState<HomeMedia[]>([]);
   const [englishContents, setEnglishContents] = useState<HomeMedia[]>([]);
@@ -25,9 +23,7 @@ const HomePage: React.FC = () => {
   const [koreanSeries, setKoreanSeries] = useState<HomeMedia[]>([]);
   const [popularMovies, setPopularMovies] = useState<HomeMedia[]>([]);
   const [nowPlayingMovies, setNowPlayingMovies] = useState<HomeMedia[]>([]);
-  const [sFAndFantasySeries, setSFAndFantasySeries] = useState<HomeMedia[]>(
-    []
-  );
+  const [sFAndFantasySeries, setSFAndFantasySeries] = useState<HomeMedia[]>([]);
 
   // fetchDataHome 컴포넌트는 fetchData로 따로 컴포넌트화 시켜서 재사용할 수 있지만
   // 각 page에서 개인 api 연결 공부를 위해 page에 넣음
@@ -36,7 +32,7 @@ const HomePage: React.FC = () => {
       const response = await instance.get(url);
       const results = response.data.results;
 
-			// backdrop_path가 없는 부분 filtering
+      // backdrop_path가 없는 부분 filtering
       const filteredResults = results.filter(
         (item: any) => item.backdrop_path !== null
       );

--- a/src/pages/HomePage/page.tsx
+++ b/src/pages/HomePage/page.tsx
@@ -4,8 +4,10 @@ import requests from "../../api/requests";
 import CardList from "../../components/CardList";
 import instance from "../../api/axios";
 import PosterList from "../../components/PosterList";
+import { MediaType } from "../../models/Media";
 
 interface HomeMedia {
+  type: MediaType;
   id: number;
   title: string;
   backdrop_path: string;
@@ -203,14 +205,17 @@ const HomePage: React.FC = () => {
           cardProps={forYou.map((item) => ({
             id: item.id,
             backdrop_path: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+            type: MediaType.TV,
           }))}
         />
         <PosterList
           title="오늘 대한민국의 TOP 10 시리즈"
-          posterProps={todayTop10SeriesKR.map((item) => ({
+          posterProps={todayTop10SeriesKR.map((item, index) => ({
             id: item.id,
             poster_path: `https://image.tmdb.org/t/p/w500${item.poster_path}`,
             backdrop_path: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+            type: MediaType.TV,
+            rank: index + 1,
           }))}
         />
         <CardList
@@ -218,6 +223,7 @@ const HomePage: React.FC = () => {
           cardProps={realitySeries.map((item) => ({
             id: item.id,
             backdrop_path: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+            type: MediaType.TV,
           }))}
         />
         <CardList
@@ -225,6 +231,7 @@ const HomePage: React.FC = () => {
           cardProps={topRatedSeries.map((item) => ({
             id: item.id,
             backdrop_path: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+            type: MediaType.TV,
           }))}
         />
         <CardList
@@ -232,6 +239,7 @@ const HomePage: React.FC = () => {
           cardProps={englishContents.map((item) => ({
             id: item.id,
             backdrop_path: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+            type: MediaType.TV,
           }))}
         />
         <CardList
@@ -239,6 +247,7 @@ const HomePage: React.FC = () => {
           cardProps={uSMovies.map((item) => ({
             id: item.id,
             backdrop_path: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+            type: MediaType.MOVIE,
           }))}
         />
 
@@ -247,14 +256,17 @@ const HomePage: React.FC = () => {
           cardProps={koreanSeries.map((item) => ({
             id: item.id,
             backdrop_path: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+            type: MediaType.TV,
           }))}
         />
         <PosterList
           title="오늘 전세계의 TOP 10 영화"
-          posterProps={popularMovies.map((item) => ({
+          posterProps={popularMovies.map((item, index) => ({
             id: item.id,
             poster_path: `https://image.tmdb.org/t/p/w500${item.poster_path}`,
             backdrop_path: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+            type: MediaType.MOVIE,
+            rank: index + 1,
           }))}
         />
         <CardList
@@ -262,6 +274,7 @@ const HomePage: React.FC = () => {
           cardProps={nowPlayingMovies.map((item) => ({
             id: item.id,
             backdrop_path: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+            type: MediaType.MOVIE,
           }))}
         />
         <CardList
@@ -269,6 +282,7 @@ const HomePage: React.FC = () => {
           cardProps={sFAndFantasySeries.map((item) => ({
             id: item.id,
             backdrop_path: `https://image.tmdb.org/t/p/w500${item.backdrop_path}`,
+            type: MediaType.TV,
           }))}
         />
       </div>

--- a/src/styles/swiper.css
+++ b/src/styles/swiper.css
@@ -1,6 +1,7 @@
 .swiper {
 	overflow: visible;
 	position: relative;
+	z-index: 1;
 }
 
 .swiper-slide-prev {
@@ -12,6 +13,7 @@
 	display: flex;
 	justify-content: flex-end;
 	gap: 2px;
+	z-index: 3;
 }
 
 .swiper-pagination-bullet {


### PR DESCRIPTION
## 작업내역
- 디테일 카드 더미로 만들어서 호버 적용했습니다.
- 카드 리스트, 포스터 리스트에서 호버되는 것으로 구현했습니다.
- backdrop_path 연결해서 해당 카드의 가로 사진이 포함된 디테일 카드입니다.

- 호버되는 위치 조정했습니다.(좌우.. 디테일 살리고 싶지만 오래 걸릴까봐 여기까지 일단 구현합니다.)
- 양쪽 버튼을 z축 위로 둬서 버튼이 우선 작동하게 했습니다.

- 카드 및 디테일 카드 모두 클릭시 모달 뜨도록 연결 해놨습니다.

## 스크린샷
![image](https://github.com/user-attachments/assets/1f441b95-7a8c-4f6e-8c03-996489942bd0)
![image](https://github.com/user-attachments/assets/3fe1e6ad-6545-4a4b-9ca2-c55e14c99c9f)