### PR TITLE
카드 그리드 컴포넌트 추가 및 내가 찜한 리스트 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Footer from "./components/Footer";
 import HomePage from "./pages/HomePage/page";
 import DetailModal from "./components/DetailModal/page";
 import { MediaType } from "./models/Media";
+import MyList from "./pages/MyList/page";
 
 const Layout = () => {
 	return (
@@ -30,6 +31,7 @@ function App() {
 				<Route path="/" element={<Layout />}>
 					<Route index element={<HomePage />} />
 					<Route path="browse" element={<HomePage />} />
+					<Route path="browse/my-list" element={<MyList />} />
 					<Route
 						path="movie/:id"
 						element={<DetailModal mediaType={MediaType.MOVIE} />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,42 +8,45 @@ import HomePage from "./pages/HomePage/page";
 import DetailModal from "./components/DetailModal/page";
 import { MediaType } from "./models/Media";
 import MyList from "./pages/MyList/page";
+import { FavoriteProvider } from "./context/FavoriteContext";
 
 const Layout = () => {
-	return (
-		<div>
-			<NavBar />
+  return (
+    <div>
+      <NavBar />
 
-			<Outlet />
+      <Outlet />
 
-			<Footer />
-		</div>
-	);
+      <Footer />
+    </div>
+  );
 };
 
 function App() {
-	const location = useLocation();
-	const state = location.state as { backgroundLocation?: Location };
-	const background = state?.backgroundLocation;
-	return (
-		<div className="app">
-			<Routes location={background || location}>
-				<Route path="/" element={<Layout />}>
-					<Route index element={<HomePage />} />
-					<Route path="browse" element={<HomePage />} />
-					<Route path="browse/my-list" element={<MyList />} />
-					<Route
-						path="movie/:id"
-						element={<DetailModal mediaType={MediaType.MOVIE} />}
-					/>
-					<Route
-						path="tv/:id"
-						element={<DetailModal mediaType={MediaType.TV} />}
-					/>
-				</Route>
-			</Routes>
-		</div>
-	);
+  const location = useLocation();
+  const state = location.state as { backgroundLocation?: Location };
+  const background = state?.backgroundLocation;
+  return (
+    <FavoriteProvider>
+      <div className="app">
+        <Routes location={background || location}>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<HomePage />} />
+            <Route path="browse" element={<HomePage />} />
+            <Route path="browse/my-list" element={<MyList />} />
+            <Route
+              path="movie/:id"
+              element={<DetailModal mediaType={MediaType.MOVIE} />}
+            />
+            <Route
+              path="tv/:id"
+              element={<DetailModal mediaType={MediaType.TV} />}
+            />
+          </Route>
+        </Routes>
+      </div>
+    </FavoriteProvider>
+  );
 }
 
 export default App;

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -56,13 +56,18 @@ const CardGrid: React.FC<CardGridProps> = ({ cardProps }) => {
               }
             }}
           >
-            <Card id={item.id} backdrop_path={item.backdrop_path} />
+            <Card
+              id={item.id}
+              backdrop_path={item.backdrop_path}
+              type={item.type}
+            />
           </div>
         ))}
       </div>
       {hoveredItem && hoverPosition && (
         <DummyDetailCard
           id={hoveredItem.id}
+          type={hoveredItem.type}
           backdrop_path={hoveredItem.backdrop_path}
           style={{
             position: "absolute",

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -19,9 +19,6 @@ const CardGrid: React.FC<CardGridProps> = ({ cardProps }) => {
   );
 
   const handleCardMouseEnter = (item: CardProps, rect: DOMRect) => {
-    console.log("Card BoundingClientRect:", rect);
-    console.log("scroll:", window.scrollY);
-
     setHoveredItem(item);
     setHoverPosition({
       top: rect.top + window.scrollY,
@@ -29,8 +26,7 @@ const CardGrid: React.FC<CardGridProps> = ({ cardProps }) => {
     });
   };
 
-  const handleDetailMouseEnter = () => {
-  };
+  const handleDetailMouseEnter = () => {};
 
   const handleDetailMouseLeave = () => {
     setHoveredItem(null);

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from "react";
+import Card, { CardProps } from "./Card";
+import DummyDetailCard from "./__DummyDetailCard";
+
+interface HoverPosition {
+  top: number;
+  left: number;
+}
+
+interface CardGridProps {
+  cardProps: CardProps[];
+}
+
+const CardGrid: React.FC<CardGridProps> = ({ cardProps }) => {
+  // 디테일 카드 호버 부분
+  const [hoveredItem, setHoveredItem] = useState<CardProps | null>(null);
+  const [hoverPosition, setHoverPosition] = useState<HoverPosition | null>(
+    null
+  );
+
+  const handleCardMouseEnter = (item: CardProps, rect: DOMRect) => {
+    console.log("Card BoundingClientRect:", rect);
+    console.log("scroll:", window.scrollY);
+
+    setHoveredItem(item);
+    setHoverPosition({
+      top: rect.top + window.scrollY,
+      left: rect.left + rect.width / 2,
+    });
+  };
+
+  const handleDetailMouseEnter = () => {
+  };
+
+  const handleDetailMouseLeave = () => {
+    setHoveredItem(null);
+    setHoverPosition(null);
+  };
+
+  return (
+    <>
+      <div
+        className="CardGrid grid gap-x-1 gap-y-10
+        sm:grid-cols-3 
+        md:grid-cols-4 
+        lg:grid-cols-5
+        xl:grid-cols-6"
+      >
+        {cardProps.map((item) => (
+          <div
+            onMouseEnter={(event) => {
+              const rect = (
+                event.currentTarget as HTMLElement
+              ).getBoundingClientRect();
+              handleCardMouseEnter(item, rect);
+            }}
+            onMouseLeave={() => {
+              if (!hoveredItem) {
+                setHoveredItem(null);
+              }
+            }}
+          >
+            <Card id={item.id} backdrop_path={item.backdrop_path} />
+          </div>
+        ))}
+      </div>
+      {hoveredItem && hoverPosition && (
+        <DummyDetailCard
+          id={hoveredItem.id}
+          backdrop_path={hoveredItem.backdrop_path}
+          style={{
+            position: "absolute",
+            top: hoverPosition.top,
+            left: hoverPosition.left,
+            transform: "translate(-50%, -25%)",
+            zIndex: 10,
+          }}
+          isActive={true}
+          onMouseEnter={handleDetailMouseEnter}
+          onMouseLeave={handleDetailMouseLeave}
+        />
+      )}
+    </>
+  );
+};
+
+export default CardGrid;

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -42,9 +42,6 @@ const CardList: React.FC<CardListProps> = ({ title, cardProps }) => {
   );
 
   const handleCardMouseEnter = (item: CardProps, rect: DOMRect) => {
-    console.log("Card BoundingClientRect:", rect);
-    console.log("scroll:", window.scrollY);
-
     setHoveredItem(item);
     setHoverPosition({
       top: rect.top + window.scrollY,

--- a/src/components/PosterList.tsx
+++ b/src/components/PosterList.tsx
@@ -48,10 +48,7 @@ const PosterList: React.FC<PosterListProps> = ({ title, posterProps }) => {
   );
 
   const handleCardMouseEnter = (item: CardProps, rect: DOMRect) => {
-    console.log("Card BoundingClientRect:", rect);
-    console.log("scroll:", window.scrollY);
-
-    setHoveredItem(item);
+   	setHoveredItem(item);
     setHoverPosition({
       top: rect.top + window.scrollY,
       left: rect.left + rect.width / 2,

--- a/src/components/__DummyDetailCard.tsx
+++ b/src/components/__DummyDetailCard.tsx
@@ -47,7 +47,7 @@ const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
   return (
     // 기존 w=256 h=318px
     <div
-      className={`dummy-detail-card w-64 h-80 rounded-md bg-[#181818] text-white shadow-lg overflow-hidden absolute z-10 transition-all duration-500  
+      className={`dummy-detail-card w-64 h-80 rounded-md bg-[#181818] text-white shadow-lg overflow-hidden absolute z-50 transition-all duration-500  
         ${visible ? "opacity-100 scale-100" : "opacity-0 scale-0"}`}
       style={style}
       onMouseEnter={onMouseEnter} // 디테일 카드 유지

--- a/src/components/__DummyDetailCard.tsx
+++ b/src/components/__DummyDetailCard.tsx
@@ -22,21 +22,20 @@ const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
   onClick,
 }) => {
   const [visible, setVisible] = useState(false);
-  const { addFavorite } = useFavorite();
+  const navigate = useNavigate();
+  const { favorites, addFavorite, removeFavorite } = useFavorite();
 
+	// 디테일 카드 호버 부분
   useEffect(() => {
-    // id(backdrop_path) 변경 시 즉시 숨김
     setVisible(false);
 
-    // isActive가 true일 때 약간의 딜레이 후 보이도록 설정
     if (isActive) {
       const timeout = setTimeout(() => setVisible(true), 1000);
       return () => clearTimeout(timeout);
     }
   }, [backdrop_path, isActive]);
 
-  const navigate = useNavigate();
-
+  // 클릭해서 모달 띄우는 부분
   const handleClickCard = () => {
     // navigate("/movie/1241982");
     navigate("/tv/1408");

--- a/src/components/__DummyDetailCard.tsx
+++ b/src/components/__DummyDetailCard.tsx
@@ -81,27 +81,47 @@ const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
           className="favorite-button w-7 h-7 flex items-center justify-center rounded-full border-2 border-gray-300 hover:border-white z-30"
           onClick={handleFavoriteClick}
         >
-          <svg
-            width="80px"
-            height="80px"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <rect width="24" height="24" fill="none" />
-            <path
-              d="M12 6V18"
-              stroke="#ffffff"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M6 12H18"
-              stroke="#ffffff"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          {isFavorite ? (
+            <svg
+              className="checked-button"
+              width="80px"
+              height="80px"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5 12L10 17L20 7"
+                stroke="#ffffff"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          ) : (
+            <svg
+              className="plus-button"
+              width="80px"
+              height="80px"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect width="24" height="24" fill="none" />
+              <path
+                d="M12 6V18"
+                stroke="#ffffff"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M6 12H18"
+                stroke="#ffffff"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          )}
         </button>
       </div>
     </div>

--- a/src/components/__DummyDetailCard.tsx
+++ b/src/components/__DummyDetailCard.tsx
@@ -42,14 +42,17 @@ const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
     navigate("/tv/1408");
   };
 
+  // 찜 목록 추가, 삭제 부분
+  const isFavorite = favorites.some((fav) => fav.id === id);
+
   const handleFavoriteClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    console.log("Favorite button clicked!");
 
-    addFavorite({
-      id,
-      backdrop_path,
-    });
+    if (isFavorite) {
+      removeFavorite(id);
+    } else {
+      addFavorite({ id, backdrop_path });
+    }
   };
 
   return (

--- a/src/components/__DummyDetailCard.tsx
+++ b/src/components/__DummyDetailCard.tsx
@@ -41,7 +41,7 @@ const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
   return (
     // 기존 w=256 h=318px
     <div
-      className={`dummy-detail-card w-64 h-80 rounded-md bg-white text-black overflow-hidden absolute z-10 transition-all duration-500  
+      className={`dummy-detail-card w-64 h-80 rounded-md bg-[#181818] text-white shadow-lg overflow-hidden absolute z-10 transition-all duration-500  
         ${visible ? "opacity-100 scale-100" : "opacity-0 scale-0"}`}
       style={style}
       onMouseEnter={onMouseEnter} // 디테일 카드 유지
@@ -71,13 +71,13 @@ const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
             <rect width="24" height="24" fill="none" />
             <path
               d="M12 6V18"
-              stroke="#000000"
+              stroke="#ffffff"
               strokeLinecap="round"
               strokeLinejoin="round"
             />
             <path
               d="M6 12H18"
-              stroke="#000000"
+              stroke="#ffffff"
               strokeLinecap="round"
               strokeLinejoin="round"
             />

--- a/src/components/__DummyDetailCard.tsx
+++ b/src/components/__DummyDetailCard.tsx
@@ -38,6 +38,12 @@ const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
     navigate("/tv/1408");
   };
 
+  const handleFavoriteClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    console.log("Favorite button clicked!");
+    // 기능 추가 예정
+  };
+
   return (
     // 기존 w=256 h=318px
     <div
@@ -59,8 +65,11 @@ const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
         />
       </div>
       {/* 원래 h=174px */}
-      <div className="dummy-detail-card-contents w-64 h-44 p-4">
-        <button className="w-6 h-6 flex items-center justify-center rounded-full border-2 border-gray-300 hover:bg-gray-100">
+      <div className="dummy-detail-card-contents w-64 h-44 p-5">
+        <button
+          className="favorite-button w-7 h-7 flex items-center justify-center rounded-full border-2 border-gray-300 hover:border-white z-30"
+          onClick={handleFavoriteClick}
+        >
           <svg
             width="80px"
             height="80px"

--- a/src/components/__DummyDetailCard.tsx
+++ b/src/components/__DummyDetailCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useFavorite } from "../context/FavoriteContext";
 
 interface DummyDetailCardProps {
   id: number;
@@ -12,6 +13,7 @@ interface DummyDetailCardProps {
 }
 
 const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
+  id,
   backdrop_path,
   style,
   isActive,
@@ -20,6 +22,8 @@ const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
   onClick,
 }) => {
   const [visible, setVisible] = useState(false);
+  const { addFavorite } = useFavorite();
+
   useEffect(() => {
     // id(backdrop_path) 변경 시 즉시 숨김
     setVisible(false);
@@ -41,7 +45,11 @@ const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
   const handleFavoriteClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     console.log("Favorite button clicked!");
-    // 기능 추가 예정
+
+    addFavorite({
+      id,
+      backdrop_path,
+    });
   };
 
   return (

--- a/src/components/__DummyDetailCard.tsx
+++ b/src/components/__DummyDetailCard.tsx
@@ -53,7 +53,7 @@ const DummyDetailCard: React.FC<DummyDetailCardProps> = ({
     if (isFavorite) {
       removeFavorite(id);
     } else {
-      addFavorite({ id, backdrop_path });
+      addFavorite({ id, backdrop_path, type });
     }
   };
 

--- a/src/context/FavoriteContext.tsx
+++ b/src/context/FavoriteContext.tsx
@@ -1,14 +1,16 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
+import { MediaType } from "../models/Media";
 
 interface FavoriteItem {
   id: number;
+  type: MediaType;
   backdrop_path: string;
 }
 
 interface FavoriteContextProps {
   favorites: FavoriteItem[];
   addFavorite: (item: FavoriteItem) => void;
-	removeFavorite: (id: number) => void;
+  removeFavorite: (id: number) => void;
 }
 
 const FavoriteContext = createContext<FavoriteContextProps | undefined>(
@@ -26,7 +28,7 @@ export const useFavorite = () => {
 export const FavoriteProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-	// 상태 변경 해주는 것 + 원래 있던 거 불러오기
+  // 상태 변경 해주는 것 + 원래 있던 거 불러오기
   const [favorites, setFavorites] = useState<FavoriteItem[]>(() => {
     const storedFavorites = localStorage.getItem("favorites");
     if (storedFavorites) {
@@ -58,12 +60,14 @@ export const FavoriteProvider: React.FC<{ children: React.ReactNode }> = ({
   };
 
   // 아이템 삭제
-	const removeFavorite = (id: number) => {
+  const removeFavorite = (id: number) => {
     setFavorites((prev) => prev.filter((item) => item.id !== id));
   };
 
   return (
-    <FavoriteContext.Provider value={{ favorites, addFavorite, removeFavorite }}>
+    <FavoriteContext.Provider
+      value={{ favorites, addFavorite, removeFavorite }}
+    >
       {children}
     </FavoriteContext.Provider>
   );

--- a/src/context/FavoriteContext.tsx
+++ b/src/context/FavoriteContext.tsx
@@ -8,6 +8,7 @@ interface FavoriteItem {
 interface FavoriteContextProps {
   favorites: FavoriteItem[];
   addFavorite: (item: FavoriteItem) => void;
+	removeFavorite: (id: number) => void;
 }
 
 const FavoriteContext = createContext<FavoriteContextProps | undefined>(
@@ -58,10 +59,13 @@ export const FavoriteProvider: React.FC<{ children: React.ReactNode }> = ({
     });
   };
 
-  // 아이템 삭제 추가 부분
+  // 아이템 삭제
+	const removeFavorite = (id: number) => {
+    setFavorites((prev) => prev.filter((item) => item.id !== id));
+  };
 
   return (
-    <FavoriteContext.Provider value={{ favorites, addFavorite }}>
+    <FavoriteContext.Provider value={{ favorites, addFavorite, removeFavorite }}>
       {children}
     </FavoriteContext.Provider>
   );

--- a/src/context/FavoriteContext.tsx
+++ b/src/context/FavoriteContext.tsx
@@ -1,0 +1,52 @@
+import React, { createContext, useContext, useState } from "react";
+
+interface FavoriteItem {
+  id: number;
+  backdrop_path: string;
+}
+
+interface FavoriteContextProps {
+  favorites: FavoriteItem[];
+  addFavorite: (item: FavoriteItem) => void;
+}
+
+const FavoriteContext = createContext<FavoriteContextProps | undefined>(
+  undefined
+);
+
+export const useFavorite = () => {
+  const context = useContext(FavoriteContext);
+  if (!context) {
+    throw new Error("FavoriteProvider로 감싸지 않은거 아닐까?");
+  }
+  return context;
+};
+
+export const FavoriteProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
+
+  // 아이템 추가
+  const addFavorite = (item: FavoriteItem) => {
+    setFavorites((prev) => {
+      if (prev.some((fav) => fav.id === item.id)) {
+        return prev;
+      }
+			const updatedFavorites = [...prev, item];
+
+      console.log("찜에 들어갔나?: ", updatedFavorites); // 업데이트된 favorites 로그
+    	return updatedFavorites;
+    });
+  };
+
+	// 아이템 삭제 추가 부분
+
+  return (
+    <FavoriteContext.Provider
+      value={{ favorites, addFavorite }}
+    >
+      {children}
+    </FavoriteContext.Provider>
+  );
+};

--- a/src/context/FavoriteContext.tsx
+++ b/src/context/FavoriteContext.tsx
@@ -42,7 +42,6 @@ export const FavoriteProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // 로컬 스토리지에 저장
   useEffect(() => {
-    console.log("찜 목록 업데이트 되고 있나?: ", favorites);
     localStorage.setItem("favorites", JSON.stringify(favorites));
   }, [favorites]);
 
@@ -54,7 +53,6 @@ export const FavoriteProvider: React.FC<{ children: React.ReactNode }> = ({
       }
       const updatedFavorites = [...prev, item];
 
-      console.log("찜에 들어갔나?: ", updatedFavorites);
       return updatedFavorites;
     });
   };

--- a/src/context/FavoriteContext.tsx
+++ b/src/context/FavoriteContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
 
 interface FavoriteItem {
   id: number;
@@ -25,7 +25,25 @@ export const useFavorite = () => {
 export const FavoriteProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
+	// 상태 변경 해주는 것 + 원래 있던 거 불러오기
+  const [favorites, setFavorites] = useState<FavoriteItem[]>(() => {
+    const storedFavorites = localStorage.getItem("favorites");
+    if (storedFavorites) {
+      try {
+        return JSON.parse(storedFavorites);
+      } catch (e) {
+        console.error("로컬 스토리지에서 찜 목록을 불러오지 못했어요.", e);
+        return [];
+      }
+    }
+    return [];
+  });
+
+  // 로컬 스토리지에 저장
+  useEffect(() => {
+    console.log("찜 목록 업데이트 되고 있나?: ", favorites);
+    localStorage.setItem("favorites", JSON.stringify(favorites));
+  }, [favorites]);
 
   // 아이템 추가
   const addFavorite = (item: FavoriteItem) => {
@@ -33,19 +51,17 @@ export const FavoriteProvider: React.FC<{ children: React.ReactNode }> = ({
       if (prev.some((fav) => fav.id === item.id)) {
         return prev;
       }
-			const updatedFavorites = [...prev, item];
+      const updatedFavorites = [...prev, item];
 
-      console.log("찜에 들어갔나?: ", updatedFavorites); // 업데이트된 favorites 로그
-    	return updatedFavorites;
+      console.log("찜에 들어갔나?: ", updatedFavorites);
+      return updatedFavorites;
     });
   };
 
-	// 아이템 삭제 추가 부분
+  // 아이템 삭제 추가 부분
 
   return (
-    <FavoriteContext.Provider
-      value={{ favorites, addFavorite }}
-    >
+    <FavoriteContext.Provider value={{ favorites, addFavorite }}>
       {children}
     </FavoriteContext.Provider>
   );

--- a/src/pages/HomePage/page.tsx
+++ b/src/pages/HomePage/page.tsx
@@ -186,7 +186,7 @@ const HomePage: React.FC = () => {
         setNowPlayingMovies(nowPlayingMovieData);
         setSFAndFantasySeries(sFAndFantasySeriesData.slice(0, 36));
       } catch (error) {
-        console.log("데이터 못 가져왔지롱~", error);
+        console.log("데이터를 못 가져왔습니다.", error);
       }
     };
     fetchHome();

--- a/src/pages/MyList/page.tsx
+++ b/src/pages/MyList/page.tsx
@@ -1,9 +1,50 @@
-import React from 'react'
+import React from "react";
+import CardGrid from "../../components/CardGrid";
+
+const dummyData = [
+  {
+    id: 1,
+    title: "Example Movie 1",
+    type: "movie",
+    release_date: "2025-01-12",
+    backdrop_path:
+      "https://occ-0-4960-988.1.nflxso.net/dnm/api/v6/Qs00mKCpRvrkl3HZAN5KwEL1kpE/AAAABcS2JPIV3anXe7XByosrzf7pqj8et0NrD3boVE48aSJ7husNRjRF1XNviyxnanlYMh7IVMxmrrSHqQtOMx8QnKIR8r9d3pC4IPc.webp?r=bfe",
+    poster_path:
+      "https://occ-0-4960-988.1.nflxso.net/dnm/api/v6/mAcAr9TxZIVbINe88xb3Teg5_OA/AAAABQpaAaVDsiYwgiiE5reeGjkzHYIUTq5gYbI41fhAFsHe8I7nvn_3jlvhDLcEU-be-29ABcz9xE2Ses7o-zishjh3HMZLRqSWakOr.webp?r=a64",
+  },
+  {
+    id: 2,
+    title: "Example Series 1",
+    type: "series",
+    first_air_date: "2025-01-09",
+    backdrop_path:
+      "https://occ-0-4960-988.1.nflxso.net/dnm/api/v6/Qs00mKCpRvrkl3HZAN5KwEL1kpE/AAAABf2jhrphpnR1nDGVUbI5oghPF6ILAS6siZm0jUkVYad15O40sbHIUfJU5lkwYmOkLI4PHqV_sNsvNm59XdiFFHYlS0QQIo3t2j11dKDjutpd0vsrQI9XTpGHa6sTjP7I-OHw.jpg?r=1ca",
+    poster_path:
+      "https://occ-0-4960-988.1.nflxso.net/dnm/api/v6/mAcAr9TxZIVbINe88xb3Teg5_OA/AAAABUcJcQ4IEkbo5D2KOk_MaejlkWr1U2m2ag1xoaQt2WfWOI6lUW4BSg5cMQz_lXMImPldol5woNK_JP0GH7GfQ8JfCYZf75vzLtC5mbS7Sdh-Fpz9PFecEH1lcSjyd5Oe_QfdvieTu6fyhCe07kP94330lfkOLJ8ZVfV5v01XjlCZgud1tgzJopgmL2Io6GEk8fdpc0qaNLOqiRRqbAaG7J0JInU1xgeQnqaIf7bHvLBDHTaPRAwACUvGmQB7cNym87fuCkEDZgosAKvO27ci38XsxHtbJEwMe7yA-MQCKvAn70ECOUITfSxeslLdDMmMHR24oV7PPAXEjRDDikc4WFTThkWPxZTOyQwpoLjseVhTmW3jXvVZ9Ph9VvALLsfao1LpXbK9IgZgGBqgPbXPLQQ4UGo7WMYXpO_OKmLQeQn27w.webp?r=adf",
+  },
+  {
+    id: 3,
+    title: "Example Movie 2",
+    type: "movie",
+    release_date: "2024-11-20",
+    backdrop_path:
+      "https://occ-0-4960-988.1.nflxso.net/dnm/api/v6/Qs00mKCpRvrkl3HZAN5KwEL1kpE/AAAABXtJtp1IyQpU9bbGxP32YS2wOMJDtgogIBzxC4sSNdBoeHJ1w5LP0etCOoE30LH8TqY1cn22nUKXo4YFnjJp-u5zmeY2zDlajCM.webp?r=965",
+    poster_path:
+      "https://occ-0-4960-988.1.nflxso.net/dnm/api/v6/mAcAr9TxZIVbINe88xb3Teg5_OA/AAAABQpaAaVDsiYwgiiE5reeGjkzHYIUTq5gYbI41fhAFsHe8I7nvn_3jlvhDLcEU-be-29ABcz9xE2Ses7o-zishjh3HMZLRqSWakOr.webp?r=a64",
+  },
+];
 
 const MyList = () => {
-	return (
-		<div>MyList</div>
-	)
-}
+  return (
+    <div className="my-2 mx-12">
+      <section className="my-list-header mb-24">
+        <h1 className="text-[21px]">내가 찜한 리스트</h1>
+      </section>
+      <section className="my-list-main mb-80">
+        <CardGrid cardProps={dummyData} />
+      </section>
+    </div>
+  );
+};
 
-export default MyList
+export default MyList;

--- a/src/pages/MyList/page.tsx
+++ b/src/pages/MyList/page.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const MyList = () => {
+	return (
+		<div>MyList</div>
+	)
+}
+
+export default MyList

--- a/src/pages/MyList/page.tsx
+++ b/src/pages/MyList/page.tsx
@@ -1,47 +1,24 @@
 import React from "react";
 import CardGrid from "../../components/CardGrid";
-
-const dummyData = [
-  {
-    id: 1,
-    title: "Example Movie 1",
-    type: "movie",
-    release_date: "2025-01-12",
-    backdrop_path:
-      "https://occ-0-4960-988.1.nflxso.net/dnm/api/v6/Qs00mKCpRvrkl3HZAN5KwEL1kpE/AAAABcS2JPIV3anXe7XByosrzf7pqj8et0NrD3boVE48aSJ7husNRjRF1XNviyxnanlYMh7IVMxmrrSHqQtOMx8QnKIR8r9d3pC4IPc.webp?r=bfe",
-    poster_path:
-      "https://occ-0-4960-988.1.nflxso.net/dnm/api/v6/mAcAr9TxZIVbINe88xb3Teg5_OA/AAAABQpaAaVDsiYwgiiE5reeGjkzHYIUTq5gYbI41fhAFsHe8I7nvn_3jlvhDLcEU-be-29ABcz9xE2Ses7o-zishjh3HMZLRqSWakOr.webp?r=a64",
-  },
-  {
-    id: 2,
-    title: "Example Series 1",
-    type: "series",
-    first_air_date: "2025-01-09",
-    backdrop_path:
-      "https://occ-0-4960-988.1.nflxso.net/dnm/api/v6/Qs00mKCpRvrkl3HZAN5KwEL1kpE/AAAABf2jhrphpnR1nDGVUbI5oghPF6ILAS6siZm0jUkVYad15O40sbHIUfJU5lkwYmOkLI4PHqV_sNsvNm59XdiFFHYlS0QQIo3t2j11dKDjutpd0vsrQI9XTpGHa6sTjP7I-OHw.jpg?r=1ca",
-    poster_path:
-      "https://occ-0-4960-988.1.nflxso.net/dnm/api/v6/mAcAr9TxZIVbINe88xb3Teg5_OA/AAAABUcJcQ4IEkbo5D2KOk_MaejlkWr1U2m2ag1xoaQt2WfWOI6lUW4BSg5cMQz_lXMImPldol5woNK_JP0GH7GfQ8JfCYZf75vzLtC5mbS7Sdh-Fpz9PFecEH1lcSjyd5Oe_QfdvieTu6fyhCe07kP94330lfkOLJ8ZVfV5v01XjlCZgud1tgzJopgmL2Io6GEk8fdpc0qaNLOqiRRqbAaG7J0JInU1xgeQnqaIf7bHvLBDHTaPRAwACUvGmQB7cNym87fuCkEDZgosAKvO27ci38XsxHtbJEwMe7yA-MQCKvAn70ECOUITfSxeslLdDMmMHR24oV7PPAXEjRDDikc4WFTThkWPxZTOyQwpoLjseVhTmW3jXvVZ9Ph9VvALLsfao1LpXbK9IgZgGBqgPbXPLQQ4UGo7WMYXpO_OKmLQeQn27w.webp?r=adf",
-  },
-  {
-    id: 3,
-    title: "Example Movie 2",
-    type: "movie",
-    release_date: "2024-11-20",
-    backdrop_path:
-      "https://occ-0-4960-988.1.nflxso.net/dnm/api/v6/Qs00mKCpRvrkl3HZAN5KwEL1kpE/AAAABXtJtp1IyQpU9bbGxP32YS2wOMJDtgogIBzxC4sSNdBoeHJ1w5LP0etCOoE30LH8TqY1cn22nUKXo4YFnjJp-u5zmeY2zDlajCM.webp?r=965",
-    poster_path:
-      "https://occ-0-4960-988.1.nflxso.net/dnm/api/v6/mAcAr9TxZIVbINe88xb3Teg5_OA/AAAABQpaAaVDsiYwgiiE5reeGjkzHYIUTq5gYbI41fhAFsHe8I7nvn_3jlvhDLcEU-be-29ABcz9xE2Ses7o-zishjh3HMZLRqSWakOr.webp?r=a64",
-  },
-];
+import { useFavorite } from "../../context/FavoriteContext";
 
 const MyList = () => {
+	const { favorites } = useFavorite();
+
   return (
     <div className="my-2 mx-12">
       <section className="my-list-header mb-24">
         <h1 className="text-[21px]">내가 찜한 리스트</h1>
       </section>
       <section className="my-list-main mb-80">
-        <CardGrid cardProps={dummyData} />
+        {favorites.length > 0 ? (
+					<CardGrid cardProps={favorites} />
+				) : (
+					<div className="flex justify-center items-center h-[200px]">
+						<p className="text-[#666666]">아직 찜하신 콘텐츠가 없습니다.</p>
+						<div className="h-[300px]"></div>
+					</div>
+				)}
       </section>
     </div>
   );


### PR DESCRIPTION
## 작업내역
### CardGrid 컴포넌트

- [x] 내가 찜한 리스트, 언어별로 찾아보기, 검색 결과 페이지에서 사용되는 CardGrid 컴포넌트를 추가했습니다.
- 일반 카드 컴포넌트에 디테일 카드가 호버되는 기능이 있는 컴포넌트 입니다.
- cardProps를 받습니다. 
  `<CardGrid cardProps={ id, backdrop_path, type } />`
- [x] 컴포넌트에서 호버하면 생기는 디테일 카드를 클릭하면 모달 창이 뜨도록 했습니다. 

- [x] + 버튼은 별도로 클릭이 가능하며 다른 기능을 수행합니다.
  - 이 컴포넌트에서 호버된 디테일 카드에 + 버튼 클릭하면 찜 목록으로 add 되고 버튼이 체크로 바뀝니다.
  - 체크 버튼을 클릭하면 찜 목록에서 remove되고 + 버튼으로 다시 바뀝니다.

### 내가 찜한 리스트 페이지
- API 를 사용할까 하다가.. 로그인 해서 account_id, session_id, Body Params가 필요해서 이 부분은 더 공부해야 할 것 같아서.. 로컬 스토리지 이용해서 저장하고 리스트에 보여지도록 했습니다.
- [x] FavoriteContext를 만들어 찜 리스트에서 add 하거나 remove 하는 커스텀 훅을 제작했습니다.
- [x] App.tsx에 Provider로 전체를 감싸서 모든 페이지에서 사용이 가능하도록 했습니다. (컨텍스트.. 배웠는데 어떻게 쓰는 건지는 알겠는데.. 완벽히 이해는 못했어요.
- [x] 디테일 카드의 버튼과 연동되며, 해당 컨텐츠의 item - id, type, backdrop_path를 받아오도록 했습니다. 해당 컨텐츠의 item으로 add 해서 로컬 스토리지에 저장하고 이를 찜 리스트에 보여지게 했습니다. id를 확인해 remove하여 로컬 스토리지에서 삭제하고 찜 리스트에서 보여지지 않습니다.


## 스크린샷
#### <카드 그리드 컴포넌트>
아래 스크린샷과 같이 스와이퍼 없이 구현됩니다.
![image](https://github.com/user-attachments/assets/ae256f85-a426-443f-a082-74b1cd9cbfcf)

#### <내가 찜한 리스트 페이지>
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/ad104945-79d3-4875-8eed-acabb8cd746f" />

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/4353b25f-da2f-49fd-a194-dde224553572" />

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/571bf4f9-26cc-462a-a9c2-b1d5246895c7" />

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/95e3af31-9eab-4554-add3-669d10d28d77" />
