### PR TITLE
카드 컴포넌트들 버그 수정 및 디테일 추가

### DIFF
--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -37,13 +37,16 @@ const CardList: React.FC<CardListProps> = ({ title, mediaList }) => {
   };
 
   // 디테일 카드 호버 부분
-  const [hoveredItem, setHoveredItem] = useState<Media | null>(null);
+  const [hoveredItem, setHoveredItem] = useState<{
+    media: Media;
+    index: number;
+  } | null>(null);
   const [hoverPosition, setHoverPosition] = useState<HoverPosition | null>(
     null
   );
 
-  const handleCardMouseEnter = (media: Media, rect: DOMRect) => {
-    setHoveredItem(media);
+  const handleCardMouseEnter = (media: Media, index: number, rect: DOMRect) => {
+    setHoveredItem({ media, index });
     setHoverPosition({
       top: rect.top + window.scrollY,
       left: rect.left + rect.width / 2,
@@ -57,6 +60,14 @@ const CardList: React.FC<CardListProps> = ({ title, mediaList }) => {
   const handleDetailMouseLeave = () => {
     setHoveredItem(null);
     setHoverPosition(null);
+  };
+
+  const getSlidesPerView = (): number => {
+    const width = window.innerWidth;
+    if (width >= 1378) return 6;
+    if (width >= 998) return 5;
+    if (width >= 625) return 4;
+    return 3;
   };
 
   return (
@@ -121,7 +132,7 @@ const CardList: React.FC<CardListProps> = ({ title, mediaList }) => {
                 const rect = (
                   event.currentTarget as HTMLElement
                 ).getBoundingClientRect();
-                handleCardMouseEnter(media, rect);
+                handleCardMouseEnter(media, index, rect);
               }}
               onMouseLeave={() => {
                 if (!hoveredItem) {
@@ -136,12 +147,45 @@ const CardList: React.FC<CardListProps> = ({ title, mediaList }) => {
         {/* 디테일 카드 호버 */}
         {hoveredItem && hoverPosition && (
           <DetailCard
-            media={hoveredItem}
+            media={hoveredItem.media}
             style={{
               position: "absolute",
               top: "cal(hoverPosition.top - scrollY)",
               left: hoverPosition.left,
-              transform: "translate(-75%, -60%)",
+              transform: (() => {
+                const hoveredElement = document.querySelector(
+                  `.swiper-slide[data-swiper-slide-index="${hoveredItem.index}"]`
+                );
+
+                const activeIndex = parseInt(
+                  document
+                    .querySelector(".swiper-slide-active")
+                    ?.getAttribute("data-swiper-slide-index") || "0",
+                  10
+                );
+                const slidesPerView = getSlidesPerView();
+
+                const targetIndex = activeIndex + (slidesPerView - 1);
+                if (hoveredElement) {
+                  const isActive = hoveredElement.classList.contains(
+                    "swiper-slide-active"
+                  );
+                  const isTarget =
+                    parseInt(
+                      hoveredElement.getAttribute("data-swiper-slide-index") ||
+                        "-1",
+                      10
+                    ) === targetIndex;
+
+                  if (isActive) {
+                    return "translate(-52%, -60%)";
+                  } else if (isTarget) {
+                    return "translate(-78%, -60%)";
+                  }
+                }
+
+                return "translate(-75%, -60%)";
+              })(),
               zIndex: 10,
             }}
             isActive={true}

--- a/src/components/DetailCard.tsx
+++ b/src/components/DetailCard.tsx
@@ -32,6 +32,7 @@ const DetailCard: React.FC<DetailCardProps> = ({
 }) => {
   const [newMedia, setNewMedia] = useState<Media | null>(null);
   const [visible, setVisible] = useState(false);
+  const [showBanner, setShowBanner] = useState<string | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
   const { favorites, addFavorite, removeFavorite } = useFavorite();
@@ -56,6 +57,30 @@ const DetailCard: React.FC<DetailCardProps> = ({
 
     fetchMediaNew();
   }, [isActive, media]);
+
+  console.log("데이터:", newMedia);
+
+  // "새로운 시즌" 또는 "최신 등록" 배너 표시 여부 확인
+  useEffect(() => {
+    if (!newMedia) return;
+
+    const releaseDate = new Date(newMedia.releaseDate);
+    const currentDate = new Date();
+
+    const daysDifference = Math.floor(
+      (currentDate.getTime() - releaseDate.getTime()) / (1000 * 3600 * 24)
+    );
+
+    if (daysDifference <= 31 && daysDifference >= 0) {
+      if (media.type === MediaType.TV) {
+        setShowBanner("새로운 시즌");
+      } else if (media.type === MediaType.MOVIE) {
+        setShowBanner("최신 등록");
+      }
+    } else {
+      setShowBanner(null);
+    }
+  }, [newMedia]);
 
   // 디테일 카드 호버 부분
   useEffect(() => {
@@ -133,12 +158,17 @@ const DetailCard: React.FC<DetailCardProps> = ({
         console.log("play");
       }}
     >
-      <div className="detail-card-backdrop w-full h-auto">
+      <div className="detail-card-backdrop w-full h-auto relative">
         <img
           className="w-full h-full object-cover"
           src={`https://image.tmdb.org/t/p/original/${media.backdropPath}`}
           alt=""
         />
+        {showBanner && (
+          <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 bg-red-600 text-white text-md font-extrabold px-3 py-[2px] rounded-t-[3px]">
+            {showBanner}
+          </div>
+        )}
       </div>
       <div className="detail-card-contents flex flex-col gap-5 w-full h-auto p-5">
         <div className="buttons flex flex-row justify-between">

--- a/src/components/DetailCard.tsx
+++ b/src/components/DetailCard.tsx
@@ -58,8 +58,6 @@ const DetailCard: React.FC<DetailCardProps> = ({
     fetchMediaNew();
   }, [isActive, media]);
 
-  console.log("데이터:", newMedia);
-
   // "새로운 시즌" 또는 "최신 등록" 배너 표시 여부 확인
   useEffect(() => {
     if (!newMedia) return;

--- a/src/components/DetailCard.tsx
+++ b/src/components/DetailCard.tsx
@@ -11,6 +11,7 @@ import {
 } from "../models/Media";
 import { convertMinutesToHoursAndMinutes } from "../util/calculate";
 import instance from "../api/axios";
+import Tooltip from "./Tooltip";
 
 interface DetailCardProps {
   media: Media;
@@ -56,9 +57,9 @@ const DetailCard: React.FC<DetailCardProps> = ({
     fetchMediaNew();
   }, [isActive, media]);
 
-	// 디테일 카드 호버 부분
-	useEffect(() => {
-		setVisible(false);
+  // 디테일 카드 호버 부분
+  useEffect(() => {
+    setVisible(false);
 
     if (isActive) {
       const timeout = setTimeout(() => setVisible(true), 1000);
@@ -86,18 +87,18 @@ const DetailCard: React.FC<DetailCardProps> = ({
     }
   };
 
-	// 찜 목록 추가, 삭제 부분
-	const isFavorite = favorites.some((fav) => fav.id === media.id);
+  // 찜 목록 추가, 삭제 부분
+  const isFavorite = favorites.some((fav) => fav.id === media.id);
 
-	const handleFavoriteClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-		e.stopPropagation();
+  const handleFavoriteClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
 
-		if (isFavorite) {
-			removeFavorite(media.id);
-		} else {
-			addFavorite(media);
-		}
-	};
+    if (isFavorite) {
+      removeFavorite(media.id);
+    } else {
+      addFavorite(media);
+    }
+  };
 
   // 런타임 또는 시즌 정보 계산
   const getRuntimeOrSesaons = () => {
@@ -120,7 +121,7 @@ const DetailCard: React.FC<DetailCardProps> = ({
 
   return (
     <div
-      className={`detail-card cursor-pointer w-full h-auto max-w-64 max-h-96 rounded-md bg-[#181818] text-white shadow-lg overflow-hidden absolute z-50 transition-all duration-500  
+      className={`detail-card cursor-pointer w-full h-auto max-w-64 max-h-96 rounded-md bg-[#181818] text-white shadow-lg overflow-visible absolute z-[1002] transition-all duration-500  
         ${
           visible ? "opacity-100 scale-100" : "opacity-0 scale-0"
         } sm:max-w-64 md:max-w-72 lg:max-w-80`}
@@ -180,105 +181,117 @@ const DetailCard: React.FC<DetailCardProps> = ({
                 </g>
               </svg>
             </button>
-            <button
-              className="favorite-button w-6 h-6 flex items-center justify-center rounded-full ring-2 ring-gray-500 hover:ring-white active:bg-gray-400 active:border-3 z-30"
-              onClick={handleFavoriteClick}
+            <Tooltip
+              text={
+                isFavorite
+                  ? "내가 찜한 콘텐츠에서 삭제"
+                  : "내가 찜한 콘텐츠에 추가"
+              }
             >
-              {isFavorite ? (
-                <svg
-                  className="checked-button"
-                  width="50px"
-                  height="50px"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  transform="scale(0.8)"
-                  transform-origin="center"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M5 12L10 17L20 7"
-                    stroke="#ffffff"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              ) : (
-                <svg
-                  className="plus-button"
-                  width="80px"
-                  height="80px"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  transform="scale(0.8)"
-                  transform-origin="center"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <rect width="20" height="20" fill="none" />
-                  <path
-                    d="M12 6V18"
-                    stroke="#ffffff"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M6 12H18"
-                    stroke="#ffffff"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              )}
-            </button>
-            <button
-              className="likes-button w-6 h-6 flex items-center justify-center rounded-full ring-2 ring-gray-500 hover:ring-white active:bg-gray-400 active:border-3 z-30"
-              onClick={(e) => {
-                e.stopPropagation();
-                console.log("likes buttons clicked");
-              }}
-            >
-              <svg
-                width="800px"
-                height="800px"
-                viewBox="0 0 24 24"
-                fill="none"
-                transform="scale(0.6)"
-                transform-origin="center"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                className="favorite-button w-6 h-6 flex items-center justify-center rounded-full ring-2 ring-gray-500 hover:ring-white active:bg-gray-400 active:border-3 z-30"
+                onClick={handleFavoriteClick}
               >
-                <path
-                  d="M16.4996 5.20228C16.4996 2.76034 15.3595 1.00359 13.4932 1.00359C12.467 1.00359 12.1149 1.60496 11.747 3.00317C11.6719 3.29202 11.635 3.43266 11.596 3.57126C11.495 3.93 11.3192 4.54075 11.069 5.40227C11.0623 5.42535 11.0524 5.4471 11.0396 5.46718L8.17281 9.95284C7.49476 11.0138 6.49429 11.8293 5.31841 12.2795L4.84513 12.4607C3.5984 12.938 2.87457 14.2418 3.1287 15.5524L3.53319 17.6385C3.77462 18.8836 4.71828 19.8745 5.9501 20.1764L13.5778 22.0459C16.109 22.6663 18.6674 21.1314 19.3113 18.606L20.7262 13.0569C21.1697 11.3176 20.1192 9.54813 18.3799 9.10466C18.1175 9.03776 17.8478 9.00391 17.5769 9.00391H15.7536C16.2497 7.37102 16.4996 6.11123 16.4996 5.20228ZM4.60127 15.2669C4.48576 14.6711 4.81477 14.0785 5.38147 13.8615L5.85475 13.6803C7.33036 13.1154 8.58585 12.092 9.43674 10.7606L12.3035 6.27494C12.3935 6.13406 12.4629 5.981 12.5095 5.82043C12.7608 4.95542 12.9375 4.34143 13.0399 3.97754C13.083 3.82429 13.1239 3.66884 13.1976 3.38487C13.3875 2.66317 13.4809 2.50359 13.4932 2.50359C14.3609 2.50359 14.9996 3.48766 14.9996 5.20228C14.9996 6.08676 14.6738 7.53772 14.0158 9.51735C13.8544 10.0029 14.2158 10.5039 14.7275 10.5039H17.5769C17.7228 10.5039 17.868 10.5221 18.0093 10.5582C18.9459 10.797 19.5115 11.7497 19.2727 12.6863L17.8578 18.2354C17.4172 19.9633 15.6668 21.0135 13.9349 20.589L6.30718 18.7195C5.64389 18.5569 5.13577 18.0234 5.00577 17.3529L4.60127 15.2669Z"
-                  fill="white"
-                />
-              </svg>
-            </button>
+                {isFavorite ? (
+                  <svg
+                    className="checked-button"
+                    width="50px"
+                    height="50px"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    transform="scale(0.8)"
+                    transform-origin="center"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5 12L10 17L20 7"
+                      stroke="#ffffff"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                ) : (
+                  <svg
+                    className="plus-button"
+                    width="80px"
+                    height="80px"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    transform="scale(0.8)"
+                    transform-origin="center"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect width="20" height="20" fill="none" />
+                    <path
+                      d="M12 6V18"
+                      stroke="#ffffff"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M6 12H18"
+                      stroke="#ffffff"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                )}
+              </button>
+            </Tooltip>
+            <Tooltip text="좋아요">
+              <button
+                className="likes-button w-6 h-6 flex items-center justify-center rounded-full ring-2 ring-gray-500 hover:ring-white active:bg-gray-400 active:border-3 z-30"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  console.log("likes buttons clicked");
+                }}
+              >
+                <svg
+                  width="800px"
+                  height="800px"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  transform="scale(0.6)"
+                  transform-origin="center"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M16.4996 5.20228C16.4996 2.76034 15.3595 1.00359 13.4932 1.00359C12.467 1.00359 12.1149 1.60496 11.747 3.00317C11.6719 3.29202 11.635 3.43266 11.596 3.57126C11.495 3.93 11.3192 4.54075 11.069 5.40227C11.0623 5.42535 11.0524 5.4471 11.0396 5.46718L8.17281 9.95284C7.49476 11.0138 6.49429 11.8293 5.31841 12.2795L4.84513 12.4607C3.5984 12.938 2.87457 14.2418 3.1287 15.5524L3.53319 17.6385C3.77462 18.8836 4.71828 19.8745 5.9501 20.1764L13.5778 22.0459C16.109 22.6663 18.6674 21.1314 19.3113 18.606L20.7262 13.0569C21.1697 11.3176 20.1192 9.54813 18.3799 9.10466C18.1175 9.03776 17.8478 9.00391 17.5769 9.00391H15.7536C16.2497 7.37102 16.4996 6.11123 16.4996 5.20228ZM4.60127 15.2669C4.48576 14.6711 4.81477 14.0785 5.38147 13.8615L5.85475 13.6803C7.33036 13.1154 8.58585 12.092 9.43674 10.7606L12.3035 6.27494C12.3935 6.13406 12.4629 5.981 12.5095 5.82043C12.7608 4.95542 12.9375 4.34143 13.0399 3.97754C13.083 3.82429 13.1239 3.66884 13.1976 3.38487C13.3875 2.66317 13.4809 2.50359 13.4932 2.50359C14.3609 2.50359 14.9996 3.48766 14.9996 5.20228C14.9996 6.08676 14.6738 7.53772 14.0158 9.51735C13.8544 10.0029 14.2158 10.5039 14.7275 10.5039H17.5769C17.7228 10.5039 17.868 10.5221 18.0093 10.5582C18.9459 10.797 19.5115 11.7497 19.2727 12.6863L17.8578 18.2354C17.4172 19.9633 15.6668 21.0135 13.9349 20.589L6.30718 18.7195C5.64389 18.5569 5.13577 18.0234 5.00577 17.3529L4.60127 15.2669Z"
+                    fill="white"
+                  />
+                </svg>
+              </button>
+            </Tooltip>
           </div>
           <div className="right-buttons flex flex-row justify-end items-center">
-            <button
-              className="likes-button w-6 h-6 flex items-center justify-center rounded-full ring-2 ring-gray-500 hover:ring-white active:bg-gray-400 active:border-3 z-30"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleClickCard();
-              }}
-            >
-              <svg
-                width="800px"
-                height="800px"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
+            <Tooltip text="회차 및 상세 정보">
+              <button
+                className="likes-button w-6 h-6 flex items-center justify-center rounded-full ring-2 ring-gray-500 hover:ring-white active:bg-gray-400 active:border-3 z-30"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleClickCard();
+                }}
               >
-                <path
-                  d="M7 10L12 15L17 10"
-                  stroke="white"
-                  stroke-width="1"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </button>
+                <svg
+                  width="800px"
+                  height="800px"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M7 10L12 15L17 10"
+                    stroke="white"
+                    stroke-width="1"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </button>
+            </Tooltip>
           </div>
         </div>
         <div className="px-2 flex flex-row gap-3 items-center">

--- a/src/components/PosterList.tsx
+++ b/src/components/PosterList.tsx
@@ -94,7 +94,7 @@ const PosterList: React.FC<PosterListProps> = ({ title, mediaList }) => {
           breakpoints={{
             1378: {
               slidesPerView: 6,
-              slidesPerGroup: 6,
+              slidesPerGroup: 4,
             },
             998: {
               slidesPerView: 5,

--- a/src/components/PosterList.tsx
+++ b/src/components/PosterList.tsx
@@ -36,13 +36,16 @@ const PosterList: React.FC<PosterListProps> = ({ title, mediaList }) => {
   };
 
   // 디테일 카드 호버 부분
-  const [hoveredItem, setHoveredItem] = useState<Media | null>(null);
+  const [hoveredItem, setHoveredItem] = useState<{
+    media: Media;
+    index: number;
+  } | null>(null);
   const [hoverPosition, setHoverPosition] = useState<HoverPosition | null>(
     null
   );
 
-  const handleCardMouseEnter = (media: Media, rect: DOMRect) => {
-    setHoveredItem(media);
+  const handleCardMouseEnter = (media: Media, index: number, rect: DOMRect) => {
+    setHoveredItem({ media, index });
     setHoverPosition({
       top: rect.top + window.scrollY,
       left: rect.left + rect.width / 2,
@@ -56,6 +59,14 @@ const PosterList: React.FC<PosterListProps> = ({ title, mediaList }) => {
   const handleDetailMouseLeave = () => {
     setHoveredItem(null);
     setHoverPosition(null);
+  };
+
+  const getSlidesPerView = (): number => {
+    const width = window.innerWidth;
+    if (width >= 1378) return 6;
+    if (width >= 998) return 5;
+    if (width >= 625) return 4;
+    return 3;
   };
 
   return (
@@ -118,7 +129,7 @@ const PosterList: React.FC<PosterListProps> = ({ title, mediaList }) => {
                 const rect = (
                   event.currentTarget as HTMLElement
                 ).getBoundingClientRect();
-                handleCardMouseEnter(media, rect);
+                handleCardMouseEnter(media, index, rect);
               }}
               onMouseLeave={() => {
                 if (!hoveredItem) {
@@ -133,12 +144,45 @@ const PosterList: React.FC<PosterListProps> = ({ title, mediaList }) => {
         {/* 디테일 카드 호버 */}
         {hoveredItem && hoverPosition && (
           <DetailCard
-            media={hoveredItem}
+            media={hoveredItem.media}
             style={{
               position: "absolute",
               top: "cal(hoverPosition.top - scrollY)",
               left: hoverPosition.left,
-              transform: "translate(-75%, -70%)",
+              transform: (() => {
+                const hoveredElement = document.querySelector(
+                  `.swiper-slide[data-swiper-slide-index="${hoveredItem.index}"]`
+                );
+
+                const activeIndex = parseInt(
+                  document
+                    .querySelector(".swiper-slide-active")
+                    ?.getAttribute("data-swiper-slide-index") || "0",
+                  10
+                );
+                const slidesPerView = getSlidesPerView();
+
+                const targetIndex = activeIndex + (slidesPerView - 1);
+                if (hoveredElement) {
+                  const isActive = hoveredElement.classList.contains(
+                    "swiper-slide-active"
+                  );
+                  const isTarget =
+                    parseInt(
+                      hoveredElement.getAttribute("data-swiper-slide-index") ||
+                        "-1",
+                      10
+                    ) === targetIndex;
+
+                  if (isActive) {
+                    return "translate(-52%, -75%)";
+                  } else if (isTarget) {
+                    return "translate(-78%, -75%)";
+                  }
+                }
+
+                return "translate(-75%, -75%)";
+              })(),
               zIndex: 10,
             }}
             isActive={true}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,21 @@
+import React, { FC, ReactNode } from "react";
+import "../styles/Tooltip.css";
+
+interface TooltipProps {
+  text: string;
+	children: ReactNode;
+}
+
+const Tooltip: FC<TooltipProps> = ({ text, children }) => {
+  return (
+    <div className="tooltip-container">
+      {children}
+      <div className="tooltip">
+        <span className="tooltip-text">{text}</span>
+        <div className="tooltip-arrow"></div>
+      </div>
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/src/styles/Tooltip.css
+++ b/src/styles/Tooltip.css
@@ -1,0 +1,45 @@
+.tooltip-container {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip {
+  visibility: hidden;
+  opacity: 0;
+  background-color: rgba(251, 251, 251);
+  color: #000;
+  text-align: center;
+  border-radius: 2px;
+  font-size: 14px;
+  position: absolute;
+	padding: 2px 9px;
+  bottom: 160%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1010;
+  transition: opacity 0.2s ease-in-out;
+  white-space: nowrap;
+}
+
+/* 툴팁 아래 삼각형 */
+.tooltip-arrow {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: rgba(251, 251, 251) transparent transparent transparent;
+}
+
+.tooltip-text {
+  display: block;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+/* 마우스 호버 */
+.tooltip-container:hover .tooltip {
+  visibility: visible;
+  opacity: 1;
+}


### PR DESCRIPTION
## 작업 내용
- 스와이퍼 무한 loop 넣었는데 슬라이드 개수 모자라는 현상 수정 - 넷플릭스처럼 slidePerGroup이 유동적으로 구현해보고 싶었지만.. 뜻대로 되지는 못했고, 포스터 리스트 10개인데 가장 넓은 화면일 때 6개씩 이동하는 것에서 에러나서 버튼이 더 작동하지 않는 현상 수정하기 위해 4개씩 움직이도록 했습니다(5개로 해도 안되더 라구요.)
- 양쪽 슬라이드 카드 호버 되는 위치 화면 밖으로 나가서, 버튼 클릭 불가한 부분 조정했습니다. 버튼 클릭 가능하도록 padding 안쪽으로 이동
- 툴팁 컴포넌트 추가하여 버튼 호버시 보이도록 했습니다.
- 디테일 카드 컴포넌트의 이미지에 새로운 시즌, 최신 등록 배너 추가했습니다. 원래라면 카드와 포스터 위에도 나와야 하는데.. 데이터를 Media로 넣어놔서 영화와 시리즈 구분을 못하여 넣지 못했습니다. 

## 스크린샷
![image](https://github.com/user-attachments/assets/36918cf9-6ac5-4678-9f27-5a4751c4960e)
![image](https://github.com/user-attachments/assets/27ac2b9e-5a2f-455d-bd59-8b5bb12b4556)
![image](https://github.com/user-attachments/assets/c49be134-3f58-4872-affa-0f9087bdcc0f)
![image](https://github.com/user-attachments/assets/2660b939-b887-41e9-a928-9baf55fbab73)
![image](https://github.com/user-attachments/assets/cac48d80-b024-4617-b010-67265238eb1c)
![image](https://github.com/user-attachments/assets/95cf5466-41f0-40d5-bfcb-1a95efe399a9)

-> 사실 너무 디테일이라 안해도 된다고 생각하는데.. 너무 하고 싶어서 해버렸습니다 😸 