### PR TITLE
언어별로 찾아보기 페이지 Media 매핑과 정렬 기준 구현

### DIFF
--- a/src/components/SubHeader.tsx
+++ b/src/components/SubHeader.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useEffect } from 'react';
 
-const SubHeader = () => {
+interface SubHeaderProps {
+    onSortChange: (sortCriteria: string) => void;
+  }
+
+const SubHeader: React.FC<SubHeaderProps> = ({ onSortChange }) => {
     const [viewModeOpen, setViewModeOpen] = useState(false);
     const [selectedViewMode, setSelectedViewMode] = useState('원어');
     const [langListOpen, setLangListOpen] = useState(false);
@@ -17,7 +21,11 @@ const SubHeader = () => {
     const handleSelection = (dropdown: string, value: string) => {
         if (dropdown === 'viewMode') setSelectedViewMode(value);
         if (dropdown === 'language') setSelectedLanguage(value);
-        if (dropdown === 'sortCriteria') setSelectedSortCriteria(value);
+        if (dropdown === 'sortCriteria') {
+            setSelectedSortCriteria(value);
+            onSortChange(value);
+        }
+        
         setViewModeOpen(false);
         setLangListOpen(false);
         setSortCriteriaOpen(false);

--- a/src/pages/OriginalAudio/page.tsx
+++ b/src/pages/OriginalAudio/page.tsx
@@ -3,16 +3,8 @@ import axios from '../../api/axios';
 import requests from '../../api/requests';
 import SubHeader from '../../components/SubHeader';
 import CardGrid from '../../components/CardGrid';
-import { Media, MediaType } from '../../models/Media'; // MediaType 추가
-
-interface Movie {
-  id: number;
-  backdrop_path: string;
-  title: string;
-  overview: string;
-  genre_ids: number[];
-  release_date: string;
-}
+import { Media, Movie } from '../../models/Media';
+import { mapMediaList } from '../../models/Media';
 
 const OriginalAudio = () => {
   const [movies, setMovies] = useState<Movie[]>([]);
@@ -21,34 +13,37 @@ const OriginalAudio = () => {
   const [hasMore, setHasMore] = useState(true);
   const loadedPages = new Set<number>();
 
+  // API로 가져온 데이터를 Media 형식으로 변환
+  const mediaList: Media[] = mapMediaList({ results: movies });
+
+  // API 요청 함수
   const fetchMovies = async (startPage: number, pagesToLoad: number = 1) => {
-    if (loading) return;
+    if (loading) return; // 중복 요청 방지
     setLoading(true);
-  
+
     try {
-      // 여러 페이지를 한꺼번에 요청
       const promises = Array.from({ length: pagesToLoad }, (_, index) =>
         axios.get(requests.fetchMovies, {
           params: { page: startPage + index },
         })
       );
       const responses = await Promise.all(promises);
-  
-      // 각 페이지 데이터에서 영화 리스트 추출 및 병합
+
+      // 새로운 영화 데이터를 추출
       const newMovies = responses.flatMap((response) => response.data.results);
-  
-      // 중복 제거 후 상태 업데이트
+
       setMovies((prevMovies) => {
-        const uniqueMovies = [
+        const uniqueMovies: Movie[] = [
           ...prevMovies,
           ...newMovies.filter(
-            (movie) => !prevMovies.some((prevMovie) => prevMovie.id === movie.id)
+            (movie: Movie) =>
+              !prevMovies.some((prevMovie: Movie) => prevMovie.id === movie.id)
           ),
         ];
         return uniqueMovies;
       });
-  
-      // 더 이상 데이터가 없으면 중단
+
+      // 더 이상 가져올 데이터가 없을 경우 처리
       setHasMore(newMovies.length > 0);
     } catch (error) {
       console.error('Failed to fetch movies:', error);
@@ -56,17 +51,20 @@ const OriginalAudio = () => {
       setLoading(false);
     }
   };
-  
-  // 초기 로드 시 여러 페이지 요청
+
+  // 초기 데이터 로드
   useEffect(() => {
-    fetchMovies(1, 3); // 3페이지를 한꺼번에 요청하여 60개 로드
+    fetchMovies(1, 3); // 첫 3페이지 로드
   }, []);
 
+  // 스크롤 이벤트 처리
   useEffect(() => {
     const handleScroll = () => {
       if (
         window.innerHeight + document.documentElement.scrollTop >=
-        document.documentElement.offsetHeight - 400
+        document.documentElement.offsetHeight - 400 &&
+        hasMore &&
+        !loading
       ) {
         setPage((prevPage) => prevPage + 1);
       }
@@ -74,28 +72,14 @@ const OriginalAudio = () => {
 
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
+  }, [hasMore, loading]);
 
+  // 페이지 변경 시 추가 데이터 로드
   useEffect(() => {
     if (page > 1) {
       fetchMovies(page);
     }
   }, [page]);
-
-  // Media 형식으로 데이터 변환
-  const mediaList: Media[] = movies.map((movie) => ({
-    id: movie.id,
-    title: movie.title,
-    type: MediaType.MOVIE, // 열거형 사용
-    backdropPath: `https://image.tmdb.org/t/p/w500${movie.backdrop_path}`,
-    posterPath: `https://image.tmdb.org/t/p/w500${movie.backdrop_path}`,
-    overview: movie.overview,
-    genres: movie.genre_ids.map((id) => ({ id, name: `Genre ${id}` })), // 기본 매핑
-    releaseDate: movie.release_date,
-    originCountry: ['US'], // 기본값
-    tagline: '', // 기본값
-    adult: false, // 기본값
-  }));
 
   return (
     <div>

--- a/src/pages/OriginalAudio/page.tsx
+++ b/src/pages/OriginalAudio/page.tsx
@@ -11,10 +11,9 @@ const OriginalAudio = () => {
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const [hasMore, setHasMore] = useState(true);
+  const [sortCriteria, setSortCriteria] = useState('추천 콘텐츠'); // 정렬 기준
   const loadedPages = new Set<number>();
 
-  // API로 가져온 데이터를 Media 형식으로 변환
-  const mediaList: Media[] = mapMediaList({ results: movies });
 
   // API 요청 함수
   const fetchMovies = async (startPage: number, pagesToLoad: number = 1) => {
@@ -81,9 +80,23 @@ const OriginalAudio = () => {
     }
   }, [page]);
 
+  const sortedMovies = [...movies].sort((a, b) => {
+    if (sortCriteria === '출시일순') {
+      return new Date(a.releaseDate).getTime() - new Date(b.releaseDate).getTime();
+    } else if (sortCriteria === '오름차순(ㄱ~Z)') {
+      return a.title.localeCompare(b.title);
+    } else if (sortCriteria === '내림차순(Z~ㄱ)') {
+      return b.title.localeCompare(a.title);
+    }
+    return 0; // 기본 정렬: 추천 콘텐츠
+  });
+
+  // API로 가져온 데이터를 Media 형식으로 변환
+  const mediaList: Media[] = mapMediaList({ results: sortedMovies });
+
   return (
     <div>
-      <SubHeader />
+      <SubHeader onSortChange={(criteria) => setSortCriteria(criteria)} />
       <div className="main__view relative min-h-[1000px]">
         <div className="mt-[4.2%] pt-[5rem] p-[0_4%]">
           <CardGrid mediaList={mediaList} />


### PR DESCRIPTION
# 작업 내역
Media.ts 를 활용해 코드 최적화
서브 헤더 바에 정렬 기준에 따라 영화가 정렬되도록 구현 
(기본값 추천 콘텐츠, 제목 오름차순과 내림차순 작동)(출시일순이 작동이 안되네요 흑흑..)

Media 매핑 얘기해주셔서 시도해보았는데 다행히 작동이 잘 되는 것 같습니다
서브 헤더 바에 이왕 만든 드롭 박스들 모양이 아니라 작동이 조금이라도 되면 재밌겠다 싶어서 손 댔다가 살짝 후회가 ㅠ..
일단 여기서 손은 더 안대고 GPT 랑 오늘 하루종일 공부해서 TIL로 남겨야할 것 같습니다

# 스크린 샷
![image](https://github.com/user-attachments/assets/37420270-75ca-4045-b0ff-5806bbbfb32f)
▲ 오름차순
![image](https://github.com/user-attachments/assets/0b5cf55b-f166-4f50-81f0-c6a2150a0492)
▲ 내림차순